### PR TITLE
fix(cli): drain PTY output on engine exit and skip raw mode on non-TTY stdout

### DIFF
--- a/crates/upmd-runtime/src/core.rs
+++ b/crates/upmd-runtime/src/core.rs
@@ -495,12 +495,17 @@ impl<C: Component> Engine<C> {
     /// 2. **Low-priority**: Background commands are processed within an 8ms time budget
     ///    to maintain stable frame rates.
     ///
-    /// Processing stops early if a quit command is executed.
+    /// If a high-priority message stops the engine, drain queued low-priority
+    /// messages once before returning so accepted PTY output reaches the final render.
     pub fn tick(&mut self) {
         // High-priority: drain all UI messages before touching background cmds
         while let Ok(msg) = self.msg_rx.try_recv() {
             self.update(msg);
             if !self.is_running {
+                // Preserve accepted PTY output before the final render.
+                while let Ok(msg) = self.cmd_rx.try_recv() {
+                    self.update(msg);
+                }
                 return;
             }
         }

--- a/crates/upmd-runtime/src/runtimes/cli/mod.rs
+++ b/crates/upmd-runtime/src/runtimes/cli/mod.rs
@@ -3,7 +3,7 @@
 //! Provides a runtime implementation for terminal applications that render
 //! plain text (ANSI-escaped) output without full-screen terminal libraries.
 
-use std::io;
+use std::io::{self, IsTerminal};
 use std::time::Duration;
 
 use crate::core::{Component, Engine};
@@ -34,6 +34,7 @@ use crate::core::{Component, Engine};
 /// ```
 pub struct Runtime {
     config: Config,
+    terminal: bool,
     start: Option<Box<dyn FnOnce() -> io::Result<()>>>,
     stop: Option<Box<dyn FnOnce()>>,
 }
@@ -85,21 +86,30 @@ impl Drop for Runtime {
 impl Runtime {
     /// Creates a new CLI runtime with default setup/cleanup.
     ///
-    /// Default setup: raw mode, hide cursor
-    /// Default cleanup: show cursor, disable raw mode
+    /// Terminal stdout gets raw mode and cursor hiding for in-place redraw.
+    /// Non-terminal stdout skips crossterm setup and keyboard event polling.
     pub fn new() -> Self {
-        Self {
+        let terminal = io::stdout().is_terminal();
+        let mut runtime = Self {
             config: Config::default(),
-            start: Some(Box::new(|| {
+            terminal,
+            start: None,
+            stop: None,
+        };
+
+        if terminal {
+            runtime.start = Some(Box::new(|| {
                 crossterm::terminal::enable_raw_mode()?;
                 let _ = crossterm::execute!(io::stdout(), crossterm::cursor::Hide);
                 Ok(())
-            })),
-            stop: Some(Box::new(|| {
+            }));
+            runtime.stop = Some(Box::new(|| {
                 let _ = crossterm::execute!(io::stdout(), crossterm::cursor::Show);
                 let _ = crossterm::terminal::disable_raw_mode();
-            })),
+            }));
         }
+
+        runtime
     }
 
     /// Configures the runtime with custom settings.
@@ -156,9 +166,10 @@ impl<C: Component + Input + Output> crate::Runtime<C> for Runtime {
             start()?;
         }
 
+        let is_tty = self.terminal;
         let frame_duration = Duration::from_millis(self.config.poll_timeout_ms);
         while engine.is_running {
-            if crossterm::event::poll(frame_duration).unwrap_or(false) {
+            if is_tty && crossterm::event::poll(frame_duration).unwrap_or(false) {
                 loop {
                     if let Ok(evt) = crossterm::event::read() {
                         if let Some(msg) = engine.component.action(evt) {
@@ -170,6 +181,9 @@ impl<C: Component + Input + Output> crate::Runtime<C> for Runtime {
                         break;
                     }
                 }
+            } else if !is_tty {
+                // Non-terminal stdout has no keyboard event source to poll.
+                std::thread::sleep(frame_duration);
             }
             // Process queued messages and background commands
             engine.tick();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,3 +2,35 @@
 //
 // Add smoke tests here: CLI execution, config merging, runner plan
 // production, etc. Parser unit tests belong in the upmd-parser crate.
+
+#[cfg(unix)]
+use std::process::Command;
+
+#[cfg(unix)]
+#[test]
+fn cli_block_yes_prints_pty_output_before_exit() {
+    let tmp = tempfile::tempdir().expect("create temp dir");
+    std::fs::write(tmp.path().join("listed-file.txt"), "").expect("create listed file");
+
+    let markdown = tmp.path().join("case.md");
+    std::fs::write(&markdown, "```shell\nls\n```\n").expect("write markdown");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_upmd"))
+        .arg(&markdown)
+        .args(["--cli", "-y", "-b", "1", "--working-dir"])
+        .arg(tmp.path())
+        .output()
+        .expect("run upmd");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "upmd failed\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("listed-file.txt"),
+        "CLI output should include PTY stdout\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}


### PR DESCRIPTION
**Summary**
- Drain queued PTY output before final render on engine quit to avoid dropped output
- Skip crossterm raw mode and keyboard polling when stdout is not a terminal
- Add integration test verifying PTY output appears before CLI exit