### PR TITLE
feat: render markdown images in the TUI preview via ratatui-image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +204,18 @@ name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+
+[[package]]
+name = "bitvec"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -231,6 +253,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
 
 [[package]]
 name = "byteorder-lite"
@@ -352,6 +388,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -462,7 +504,7 @@ dependencies = [
  "filedescriptor",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -807,6 +849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +882,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -874,6 +922,16 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -950,6 +1008,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "icy_sixel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85518b9086bf01117761b90e7691c0ef3236fa8adfb1fb44dd248fe5f87215d5"
+dependencies = [
+ "quantette",
+ "thiserror 2.0.19",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -985,10 +1053,25 @@ checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif",
+ "image-webp",
  "moxcms",
  "num-traits",
  "png",
  "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -1176,6 +1259,12 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1356,6 +1445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1499,6 +1589,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
 dependencies = [
  "approx",
+ "bytemuck",
  "fast-srgb8",
  "libm",
  "palette_derive",
@@ -1627,7 +1733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1724,6 +1830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1873,26 @@ name = "pxfm"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "quantette"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c98fecda8b16396ff9adac67644a523dd1778c42b58606a29df5c31ca925d174"
+dependencies = [
+ "bitvec",
+ "bytemuck",
+ "image",
+ "libm",
+ "num-traits",
+ "ordered-float 5.3.0",
+ "palette",
+ "rand 0.9.5",
+ "rand_xoshiro",
+ "rayon",
+ "ref-cast",
+ "wide",
+]
 
 [[package]]
 name = "quick-error"
@@ -1796,12 +1931,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
- "rand_core",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1809,6 +1971,24 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "ratatui"
@@ -1858,6 +2038,23 @@ dependencies = [
  "crossterm",
  "instability",
  "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-image"
+version = "11.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000b7a22eae639460bc6ec8bb1cc689ecae5b0ed21935cd7d7dd52d38270c86"
+dependencies = [
+ "base64-simd",
+ "icy_sixel",
+ "image",
+ "rand 0.8.6",
+ "ratatui",
+ "rustix 0.38.44",
+ "self_cell",
+ "thiserror 1.0.69",
+ "windows",
 ]
 
 [[package]]
@@ -1912,6 +2109,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1929,6 +2146,26 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.19",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1977,6 +2214,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1984,7 +2234,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2001,6 +2251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629516c85c29fe757770fa03f2074cf1eac43d44c02a3de9fc2ef7b0e207dfdd"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2273,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -2278,6 +2543,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,7 +2557,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2298,7 +2569,7 @@ checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
 dependencies = [
  "bitflags 2.13.0",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "signal-hook",
  "windows-sys 0.61.2",
 ]
@@ -2345,7 +2616,7 @@ dependencies = [
  "nix 0.29.0",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf",
@@ -2637,11 +2908,13 @@ dependencies = [
  "crossterm",
  "directories",
  "ignore",
+ "image",
  "insta",
  "keymap",
  "libc",
  "portable-pty",
  "ratatui",
+ "ratatui-image",
  "serde",
  "syntect",
  "tempfile",
@@ -2727,6 +3000,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vt100"
@@ -2918,7 +3197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
@@ -2958,6 +3237,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "wide"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ca908d26e4786149c48efcf6c0ea09ab0e06d1fe3c17dc1b4b0f1ca4a7e788"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2989,10 +3278,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -3000,7 +3362,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -3014,20 +3376,42 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3037,9 +3421,21 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3049,9 +3445,21 @@ checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3061,15 +3469,33 @@ checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3187,13 +3613,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "x11rb"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix",
+ "rustix 1.1.4",
  "x11rb-protocol",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ keymap = { version = "1.0.0-rc.7", features = ["crossterm"] }
 libc = "0.2"
 portable-pty = "0.9.0"
 ratatui = "0.30.2"
+ratatui-image = { version = "11.0.6", default-features = false, features = ["crossterm"] }
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 syntect = "5.3.0"
 unicode-width = { version = "0.2.2", features = ["cjk"] }
 vt100 = "0.16.2"

--- a/DEMO.md
+++ b/DEMO.md
@@ -23,6 +23,12 @@ Plain text, **bold**, *italic*, ~~strikethrough~~, `inline code`,
 Styles can be nested: ***bold italic***, **[a bold link](https://github.com/rezigned/upmd)**,
 and ~~*struck italic*~~.
 
+### Images
+
+A standalone image renders in the preview pane:
+
+![the upmd logo](.github/pages/upmd-logo.png)
+
 ### A heading with **bold**, *italic*, and `code`
 
 - A list item with **bold**, *italic*, ~~strikethrough~~, and `inline code`.

--- a/crates/upmd-parser/src/nodes.rs
+++ b/crates/upmd-parser/src/nodes.rs
@@ -3,7 +3,10 @@ use std::ops::Range;
 
 #[derive(Debug, Clone)]
 pub enum Node {
-    Heading { level: u8, text: Vec<InlineSpan> },
+    Heading {
+        level: u8,
+        text: Vec<InlineSpan>,
+    },
     Paragraph(Vec<InlineSpan>),
     BlockQuote(Vec<Node>),
     List(Vec<ListItem>),
@@ -11,6 +14,11 @@ pub enum Node {
     Table(Table),
     Text(Vec<InlineSpan>),
     ThematicBreak,
+    /// A standalone image paragraph (`![alt](src)` as its only content).
+    Image {
+        alt: String,
+        src: String,
+    },
 }
 
 /// A run of inline text with the formatting applied to it.

--- a/crates/upmd-parser/src/parser.rs
+++ b/crates/upmd-parser/src/parser.rs
@@ -126,7 +126,33 @@ impl<'a> Parser<'a> {
     // Paragraph
 
     fn parse_paragraph(&mut self) -> Node {
-        let spans = self.parse_inline_content(TagEnd::Paragraph);
+        if matches!(self.iter.peek(), Some((Event::Start(Tag::Image { .. }), _))) {
+            return self.parse_block_image();
+        }
+
+        Node::Paragraph(trim_spans(self.parse_inline_content(TagEnd::Paragraph)))
+    }
+
+    /// Parses a paragraph whose first event is an image.
+    #[inline]
+    fn parse_block_image(&mut self) -> Node {
+        let Some((Event::Start(Tag::Image { dest_url, .. }), _)) = self.iter.next() else {
+            unreachable!("peeked image event must still be present");
+        };
+        let src = dest_url.into_string();
+        let mut spans = Vec::new();
+        let mut stack = Vec::new();
+        self.push_image(&src, &mut stack, &mut spans);
+
+        if matches!(self.iter.peek(), Some((Event::End(TagEnd::Paragraph), _))) {
+            self.iter.next();
+            return Node::Image {
+                alt: inline_text(&spans),
+                src,
+            };
+        }
+
+        self.parse_inline_until(TagEnd::Paragraph, &mut stack, &mut spans);
         Node::Paragraph(trim_spans(spans))
     }
 
@@ -413,6 +439,17 @@ impl<'a> Parser<'a> {
         self.parse_inline_until(TagEnd::Image, stack, out);
         stack.pop();
         let alt = inline_text(&out[start..]);
+
+        // Empty alt (`![](path)`) yields no spans, so emit one to keep the image.
+        if out.len() == start {
+            out.push(text_span(
+                String::new(),
+                &[InlineStyle::Image {
+                    alt: String::new(),
+                    src: dest_url.to_string(),
+                }],
+            ));
+        }
         for span in &mut out[start..] {
             if let Some(InlineStyle::Image { alt: a, .. }) = span
                 .style
@@ -753,14 +790,6 @@ mod tests {
                 }],
             ),
             (
-                "![alt](image.png)",
-                "alt",
-                vec![InlineStyle::Image {
-                    alt: "alt".into(),
-                    src: "image.png".into(),
-                }],
-            ),
-            (
                 "***both***",
                 "both",
                 vec![InlineStyle::Italic, InlineStyle::Bold],
@@ -787,6 +816,51 @@ mod tests {
             assert_eq!(inline_text(spans), expected_text, "input: {markdown:?}");
             assert_eq!(spans.len(), 1, "input: {markdown:?}");
             assert_eq!(spans[0].style, expected_styles, "input: {markdown:?}");
+        }
+    }
+
+    #[test]
+    fn test_parse_block_image() {
+        for (markdown, expected_alt, expected_src) in [
+            ("![alt](image.png)", "alt", "image.png"),
+            ("![alt](./img/a.png)", "alt", "./img/a.png"),
+            ("![](/abs/path.png)", "", "/abs/path.png"),
+        ] {
+            let nodes = Cmark::new().parse(markdown).nodes;
+            match &nodes[0] {
+                Node::Image { alt, src } => {
+                    assert_eq!(alt, expected_alt, "input: {markdown:?}");
+                    assert_eq!(src, expected_src, "input: {markdown:?}");
+                }
+                other => panic!("Expected standalone Image for {markdown:?}, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn test_paragraph_with_mixed_text_and_image_stays_paragraph() {
+        let nodes = Cmark::new().parse("text ![alt](image.png)").nodes;
+        match &nodes[0] {
+            Node::Paragraph(spans) => {
+                assert!(spans.iter().any(|s| s.style.contains(&InlineStyle::Image {
+                    alt: "alt".into(),
+                    src: "image.png".into(),
+                })));
+            }
+            other => panic!("Expected Paragraph, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_multiple_images_stay_paragraph() {
+        for markdown in [
+            "![alt](image.png)![alt](image.png)",
+            "![](image.png)![](image.png)",
+        ] {
+            assert!(
+                matches!(Cmark::new().parse(markdown).nodes[0], Node::Paragraph(_)),
+                "input: {markdown:?}"
+            );
         }
     }
 

--- a/src/apps/exec.rs
+++ b/src/apps/exec.rs
@@ -107,7 +107,7 @@ pub fn merge_envs(dest: &mut Envs, captured: &Envs) {
 /// PTY output can be effectively infinite (`yes` is the canonical case), so
 /// `Out` is best-effort on the low-priority queue. Lifecycle/state messages go
 /// to the high-priority queue so `Exit`/`End` cannot sit behind stale output.
-pub fn stream_rx<M: Clone + Send + 'static>(
+pub fn stream_rx<M: Send + 'static>(
     id: CodeId,
     rx: Receiver<Stream>,
     mk_msg: impl Fn(CodeId, Stream) -> M + Send + 'static,

--- a/src/apps/tui/app.rs
+++ b/src/apps/tui/app.rs
@@ -589,12 +589,13 @@ impl App {
 }
 
 /// Messages handled by the main TUI component's event loop.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Msg {
     Content(content::Action),
     Overlay(overlay::Action),
     StreamUpdate(CodeId, crate::pty::stream::Stream),
     Notify(tui::notification::FlashMessage),
+    ImageDecoded(tui::preview::DecodedImage),
     Tick,
     Event(crossterm::event::Event),
 }
@@ -646,6 +647,10 @@ impl Component for App {
             Msg::Content(action) => self.handle_content_msg(action),
             Msg::Overlay(message) => self.handle_overlay_msg(message),
             Msg::StreamUpdate(id, stream) => self.handle_stream_update(id, stream),
+            Msg::ImageDecoded(decoded) => {
+                self.content.complete_image(decoded);
+                None
+            }
             Msg::Notify(flash) => {
                 self.notification = Some(flash);
                 None
@@ -695,7 +700,21 @@ impl App {
         {
             self.notification = None;
         }
-        None
+        let requests = self.content.take_image_requests();
+        if requests.is_empty() {
+            None
+        } else {
+            Some(Cmd::stream(move |tx| {
+                for path in requests {
+                    if tx
+                        .send(Msg::ImageDecoded(tui::preview::decode_image(path)))
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }))
+        }
     }
 
     fn is_action_enabled(&self, action: &Action) -> bool {

--- a/src/apps/tui/content.rs
+++ b/src/apps/tui/content.rs
@@ -67,6 +67,7 @@ impl Content {
             outputs,
             config.tui.inline_max_lines(),
             config.keymap.preview::<preview::Action>(),
+            preview::image_base_dir(config.file.as_deref()),
         );
 
         if let Some(id) = selected {
@@ -178,6 +179,14 @@ impl Content {
     pub fn tick(&mut self) {
         self.menu.tick();
         self.preview.tick();
+    }
+
+    pub(crate) fn take_image_requests(&self) -> Vec<std::path::PathBuf> {
+        self.preview.take_image_requests()
+    }
+
+    pub(crate) fn complete_image(&self, decoded: preview::DecodedImage) {
+        self.preview.complete_image(decoded);
     }
 
     pub fn rebuild(&mut self, outputs: &HashMap<CodeId, Task>) {

--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -158,6 +158,11 @@ pub enum LogicalLineSource {
         /// Initial content retained for search and copy before viewport painting.
         initial: Line<'static>,
     },
+    /// A standalone image block rendered via ratatui_image.
+    Image {
+        alt: String,
+        src: String,
+    },
     ThematicBreak,
     #[default]
     Newline,
@@ -385,10 +390,23 @@ impl LogicalLine {
         matches!(self.source, LogicalLineSource::TableRow { .. })
     }
 
+    #[inline]
+    pub fn is_image(&self) -> bool {
+        matches!(self.source, LogicalLineSource::Image { .. })
+    }
+
+    /// Returns the image source path for image lines.
+    pub fn image_src(&self) -> Option<&str> {
+        match &self.source {
+            LogicalLineSource::Image { src, .. } => Some(src),
+            _ => None,
+        }
+    }
+
     /// Returns `true` for lines that must not be wrapped (already sized/formatted).
     #[inline]
     pub fn is_unwrappable(&self) -> bool {
-        self.is_table() || self.is_output() || self.is_code_info()
+        self.is_table() || self.is_output() || self.is_code_info() || self.is_image()
     }
 
     /// Returns text content, preferring raw text if available.
@@ -404,6 +422,7 @@ impl LogicalLine {
             }
             LogicalLineSource::Output(text) => text.to_string(),
             LogicalLineSource::TableRow { initial, .. } => initial.to_string(),
+            LogicalLineSource::Image { alt, .. } => alt.clone(),
             LogicalLineSource::ThematicBreak | LogicalLineSource::Newline => String::new(),
         }
     }
@@ -596,6 +615,9 @@ impl LogicalLine {
                 text.lines.first().cloned().unwrap_or_else(|| Line::raw(""))
             }
             LogicalLineSource::TableRow { initial, .. } => initial.clone(),
+            LogicalLineSource::Image { alt, .. } => {
+                Line::from(alt.clone()).style(ctx.theme.image_style())
+            }
             LogicalLineSource::ThematicBreak | LogicalLineSource::Newline => Line::raw(""),
         }
     }
@@ -1053,6 +1075,18 @@ impl<'a> MarkdownRenderer<'a> {
                 self.push_line(lines, LogicalLine::thematic_break(), state.quote_depth);
                 self.push_line(lines, LogicalLine::newline(None, false), state.quote_depth);
             }
+            Node::Image { alt, src } => {
+                let line = LogicalLine {
+                    source: LogicalLineSource::Image {
+                        alt: alt.clone(),
+                        src: src.clone(),
+                    },
+                    is_block_start: true,
+                    ..LogicalLine::default()
+                };
+                self.push_line(lines, line, state.quote_depth);
+                self.push_line(lines, LogicalLine::newline(None, false), state.quote_depth);
+            }
         }
     }
 
@@ -1480,6 +1514,7 @@ mod tests {
             LogicalLineSource::CodeBody(_) => "CodeBody".to_string(),
             LogicalLineSource::Output(_) => "Output".to_string(),
             LogicalLineSource::TableRow { .. } => "Table".to_string(),
+            LogicalLineSource::Image { .. } => "Image".to_string(),
             LogicalLineSource::ThematicBreak => "ThematicBreak".to_string(),
             LogicalLineSource::Newline => "Newline".to_string(),
         }

--- a/src/apps/tui/preview/images.rs
+++ b/src/apps/tui/preview/images.rs
@@ -1,0 +1,315 @@
+//! Lazy image decoding and terminal rendering for the preview pane.
+//!
+//! Decoded images are retained so protocols can be rebuilt after a resize.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use ratatui::Frame;
+use ratatui_image::{
+    picker::Picker,
+    sliced::{SignedPosition, SlicedImage, SlicedProtocol},
+    Resize,
+};
+
+/// Result produced by a runtime image-decoding command.
+#[derive(Debug)]
+pub(crate) enum DecodedImage {
+    Loaded {
+        path: PathBuf,
+        image: image::DynamicImage,
+    },
+    Failed {
+        path: PathBuf,
+    },
+}
+
+enum State {
+    Ready {
+        sliced: SlicedProtocol,
+        image: image::DynamicImage,
+        width: usize,
+    },
+    Failed,
+}
+
+/// Loaded images keyed by resolved path.
+pub struct ImageCache {
+    picker: Option<Picker>,
+    entries: HashMap<PathBuf, State>,
+    loading: HashSet<PathBuf>,
+    pending: Vec<PathBuf>,
+    max_rows: u16,
+    width: usize,
+}
+
+impl ImageCache {
+    /// Creates an empty cache. Terminal protocol detection is deferred until
+    /// the first decoded image is processed inside the alternate screen.
+    pub fn new() -> Self {
+        Self {
+            picker: None,
+            entries: HashMap::new(),
+            loading: HashSet::new(),
+            pending: Vec::new(),
+            max_rows: 30,
+            width: 0,
+        }
+    }
+
+    /// Detects the terminal graphics protocol once.
+    fn picker(&mut self) -> &Picker {
+        if self.picker.is_none() {
+            self.picker = Some(query_picker());
+        }
+        self.picker.as_ref().expect("picker was just initialized")
+    }
+
+    /// Starts decoding an uncached image.
+    pub fn request(&mut self, src: &str, base_dir: &Path) {
+        if is_url(src) {
+            return;
+        }
+        let path = resolve_path(src, base_dir);
+        if self.entries.contains_key(&path) || self.loading.contains(&path) {
+            return;
+        }
+        self.loading.insert(path.clone());
+        self.pending.push(path);
+    }
+
+    /// Takes decode work waiting to be scheduled by the runtime.
+    pub fn take_requests(&mut self) -> Vec<PathBuf> {
+        std::mem::take(&mut self.pending)
+    }
+
+    /// Applies one runtime decode result. Returns whether image rows changed.
+    pub fn complete(&mut self, decoded: DecodedImage, width: usize) -> bool {
+        let path = match &decoded {
+            DecodedImage::Loaded { path, .. } | DecodedImage::Failed { path } => path,
+        };
+        if !self.loading.remove(path) {
+            return false;
+        }
+        match decoded {
+            DecodedImage::Loaded { path, image } => {
+                let state = self.build(width, image);
+                let ready = matches!(state, State::Ready { .. });
+                self.entries.insert(path, state);
+                ready
+            }
+            DecodedImage::Failed { path } => {
+                self.entries.insert(path, State::Failed);
+                false
+            }
+        }
+    }
+
+    /// Rebuilds cached protocols for a new width.
+    pub fn set_width(&mut self, width: usize) {
+        if width == self.width {
+            return;
+        }
+        self.width = width;
+        self.resize_all(width);
+    }
+
+    /// Builds a `SlicedProtocol` fitted into `width` columns, retaining the
+    /// decoded image so the protocol can be resized later.
+    fn build(&mut self, width: usize, image: image::DynamicImage) -> State {
+        let size = ratatui::layout::Size::new(width.max(1) as u16, self.max_rows);
+        match SlicedProtocol::new_with_resize(self.picker(), image.clone(), size, Resize::Fit(None))
+        {
+            Ok(sliced) => State::Ready {
+                sliced,
+                image,
+                width,
+            },
+            Err(err) => {
+                tracing::debug!("protocol for image: {err}");
+                State::Failed
+            }
+        }
+    }
+
+    /// Recreates every ready protocol to fit `width`.
+    fn resize_all(&mut self, width: usize) {
+        let entries = std::mem::take(&mut self.entries);
+        for (path, state) in entries {
+            let state = match state {
+                State::Ready {
+                    image,
+                    width: old_width,
+                    ..
+                } if old_width != width => self.build(width, image),
+                state => state,
+            };
+            self.entries.insert(path, state);
+        }
+    }
+
+    /// Returns the sliced protocol for an image, if it has finished loading.
+    pub fn protocol(&self, src: &str, base_dir: &Path) -> Option<&SlicedProtocol> {
+        if is_url(src) {
+            return None;
+        }
+        let path = resolve_path(src, base_dir);
+        match self.entries.get(&path) {
+            Some(State::Ready { sliced, .. }) => Some(sliced),
+            _ => None,
+        }
+    }
+
+    /// Returns the number of terminal rows an image occupies.
+    pub fn rows(&self, src: &str, base_dir: &Path) -> usize {
+        self.protocol(src, base_dir)
+            .map(|sliced| sliced.size().height.max(1) as usize)
+            .unwrap_or(1)
+    }
+
+    /// Renders the image at `src` into `area`, positioned relative to it.
+    pub fn render(
+        &self,
+        frame: &mut Frame,
+        src: &str,
+        base_dir: &Path,
+        area: ratatui::layout::Rect,
+        position: SignedPosition,
+    ) {
+        let Some(sliced) = self.protocol(src, base_dir) else {
+            return;
+        };
+        frame.render_widget(SlicedImage::new(sliced, position), area);
+    }
+}
+
+impl Default for ImageCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) fn decode_image(path: PathBuf) -> DecodedImage {
+    match image::ImageReader::open(&path) {
+        Ok(reader) => match reader.decode() {
+            Ok(image) => DecodedImage::Loaded { path, image },
+            Err(err) => {
+                tracing::debug!("image {path:?}: decode failed: {err}");
+                DecodedImage::Failed { path }
+            }
+        },
+        Err(err) => {
+            tracing::debug!("image {path:?}: open failed: {err}");
+            DecodedImage::Failed { path }
+        }
+    }
+}
+
+/// Adds the tmux hint missing from ratatui-image when `TERM=screen-*`.
+fn query_picker() -> Picker {
+    let previous = std::env::var_os("TERM_PROGRAM");
+    let needs_tmux_hint = std::env::var_os("TMUX").is_some()
+        && !std::env::var("TERM").is_ok_and(|term| term.starts_with("tmux"))
+        && previous.as_deref() != Some(std::ffi::OsStr::new("tmux"));
+    if needs_tmux_hint {
+        std::env::set_var("TERM_PROGRAM", "tmux");
+    }
+    let picker = Picker::from_query_stdio();
+    if needs_tmux_hint {
+        match previous {
+            Some(value) => std::env::set_var("TERM_PROGRAM", value),
+            None => std::env::remove_var("TERM_PROGRAM"),
+        }
+    }
+    picker.unwrap_or_else(|err| {
+        tracing::debug!("protocol query failed, using halfblocks: {err}");
+        Picker::halfblocks()
+    })
+}
+
+fn is_url(src: &str) -> bool {
+    let Some((scheme, _)) = src.split_once(':') else {
+        return false;
+    };
+    let mut chars = scheme.chars();
+    scheme.len() > 1
+        && chars.next().is_some_and(|c| c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '-' | '.'))
+}
+
+/// Resolves an image source against its document directory.
+fn resolve_path(src: &str, base_dir: &Path) -> PathBuf {
+    let path = Path::new(src);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_dir.join(path)
+    }
+}
+
+/// Returns the directory that relative image paths resolve against: the parent
+/// of the markdown file, or the current directory when no file is configured.
+pub fn image_base_dir(file: Option<&str>) -> std::path::PathBuf {
+    file.map(Path::new)
+        .and_then(|path| path.parent().map(|parent| parent.to_path_buf()))
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_path() {
+        let base = Path::new("/repo/docs");
+        let cases = [
+            ("/abs/image.png", PathBuf::from("/abs/image.png")),
+            ("img/a.png", PathBuf::from("/repo/docs/img/a.png")),
+        ];
+        for (src, expected) in cases {
+            assert_eq!(resolve_path(src, base), expected);
+        }
+    }
+
+    #[test]
+    fn test_image_base_dir_from_file_parent() {
+        let dir = image_base_dir(Some("/repo/docs/runbook.md"));
+        assert_eq!(dir, PathBuf::from("/repo/docs"));
+    }
+
+    #[test]
+    fn test_decode_request_lifecycle() {
+        let base = Path::new("/repo/docs");
+        let path = resolve_path("missing.png", base);
+        let mut cache = ImageCache::new();
+
+        cache.request("missing.png", base);
+        cache.request("missing.png", base);
+        assert_eq!(cache.take_requests(), vec![path.clone()]);
+        assert!(cache.take_requests().is_empty());
+
+        assert!(!cache.complete(DecodedImage::Failed { path }, 80));
+        cache.request("missing.png", base);
+        assert!(cache.take_requests().is_empty());
+    }
+
+    #[test]
+    fn test_url_sources() {
+        for src in [
+            "HTTPS://example.com/image.png",
+            "data:image/png;base64,AAAA",
+            "file:///tmp/image.png",
+        ] {
+            assert!(is_url(src), "input: {src}");
+            let mut cache = ImageCache::new();
+            cache.request(src, Path::new("/repo/docs"));
+            assert!(cache.loading.is_empty(), "input: {src}");
+            assert!(cache.entries.is_empty(), "input: {src}");
+        }
+
+        for src in ["img/a.png", "/abs/image.png", r"C:\images\a.png"] {
+            assert!(!is_url(src), "input: {src}");
+        }
+    }
+}

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -40,6 +40,7 @@ use std::collections::{HashMap, HashSet};
 use crate::apps::config::{
     BORDER_HEIGHT, CODE_GUTTER_WIDTH, INLINE_MAX_LINES_DEFAULT, INLINE_MAX_LINES_FRACTION,
     INLINE_MAX_LINES_MIN, OVERDRAW_FRACTION, PREVIEW_CONTENT_TOP_OFFSET, PREVIEW_CONTENT_X_OFFSET,
+    PREVIEW_FRAME_OVERHEAD,
 };
 use crate::apps::theme::Theme;
 use crate::runner::CodeId;
@@ -61,10 +62,14 @@ use upmd_runtime::{
     Component, Effect, NoOutcome,
 };
 
+mod images;
 mod search;
 mod selection;
 mod visual_lines;
 
+pub use images::image_base_dir;
+use images::ImageCache;
+pub(crate) use images::{decode_image, DecodedImage};
 use search::PreviewSearch;
 use selection::PreviewSelection;
 pub use visual_lines::{VisualLine, VisualLines};
@@ -115,6 +120,10 @@ pub struct Preview {
     copy_result: Cell<Option<bool>>,
     /// Prefix overhead in chars per code block (non-zero only for blockquote-nested blocks).
     code_prefix_overhead: HashMap<CodeId, usize>,
+    /// Cache of images referenced by the document, keyed by resolved path.
+    images: RefCell<ImageCache>,
+    /// Directory that relative image paths resolve against (the open document's dir).
+    image_base_dir: std::path::PathBuf,
 }
 
 #[derive(KeyMap, Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -153,6 +162,7 @@ impl Preview {
         outputs: &HashMap<CodeId, Task>,
         inline_max_lines_cap: usize,
         keymap: DerivedConfig<Action>,
+        image_base_dir: std::path::PathBuf,
     ) -> Self {
         let mut preview = Self {
             nodes,
@@ -172,6 +182,8 @@ impl Preview {
             copy_result: Cell::new(None),
             code_index: codes,
             code_prefix_overhead: HashMap::new(),
+            images: RefCell::new(ImageCache::new()),
+            image_base_dir,
         };
         preview.rebuild_view(outputs);
         if !preview.visual_lines.is_empty() {
@@ -182,6 +194,38 @@ impl Preview {
 
     pub fn prefer_status_gutter_for(&self, id: CodeId) {
         self.prefer_status_gutter.set(Some(id));
+    }
+
+    /// Requests loading of images in the viewport and a small overdraw margin.
+    fn request_visible_images(&self) {
+        let viewport = self.visual_lines.last_height();
+        let offset = self.state.borrow().offset();
+        let overdraw = viewport / OVERDRAW_FRACTION;
+        let start = offset.saturating_sub(overdraw);
+        let end = offset
+            .saturating_add(viewport)
+            .saturating_add(overdraw)
+            .min(self.visual_lines.len());
+        let visual_lines = self.visual_lines.borrow();
+        let mut images = self.images.borrow_mut();
+        for src in visual_lines[start..end]
+            .iter()
+            .filter(|line| line.wrap_idx == 0)
+            .filter_map(|line| self.logical_lines[line.logical_idx].image_src())
+        {
+            images.request(src, &self.image_base_dir);
+        }
+    }
+
+    pub(crate) fn take_image_requests(&self) -> Vec<std::path::PathBuf> {
+        self.images.borrow_mut().take_requests()
+    }
+
+    pub(crate) fn complete_image(&self, decoded: DecodedImage) {
+        let width = self.image_width(self.visual_lines.last_width());
+        if self.images.borrow_mut().complete(decoded, width) {
+            self.rebuild_visual_lines(self.visual_lines.last_width());
+        }
     }
 
     /// Rebuilds the logical lines from markdown nodes and then the visual lines.
@@ -257,6 +301,13 @@ impl Preview {
             &self.theme,
             &self.target_block,
             |idx| self.is_code_start_at(idx),
+            |line| {
+                if let Some(src) = line.image_src() {
+                    self.images.borrow().rows(src, &self.image_base_dir)
+                } else {
+                    1
+                }
+            },
         );
         if let Some(idx) = selected {
             // Explicit jump → scroll to target.
@@ -458,9 +509,13 @@ impl Preview {
         self.inline_max_lines.set(max_inline);
     }
 
-    /// Advances the spinner tick counter (driven by Msg::Tick).
     pub fn tick(&mut self) {
         self.spinner.tick();
+    }
+
+    /// Width available to images for a given preview width, in columns.
+    fn image_width(&self, preview_width: usize) -> usize {
+        preview_width.saturating_sub(PREVIEW_FRAME_OVERHEAD).max(1)
     }
 
     pub fn search(&mut self, term: &str) -> Vec<usize> {
@@ -592,6 +647,9 @@ impl Preview {
             viewport_width: self.visual_lines.last_width(),
         };
         let logical_line = &self.logical_lines[visual_line.logical_idx];
+        if logical_line.is_image() && visual_line.wrap_idx > 0 {
+            return Line::raw("");
+        }
         let source_line = logical_line.render_plain(&ctx);
         if logical_line.is_unwrappable() {
             source_line
@@ -987,7 +1045,10 @@ impl Output for Preview {
             .set_last_height(height.saturating_sub(BORDER_HEIGHT));
         self.last_area.set(area);
 
+        self.request_visible_images();
+
         if self.visual_lines.last_width() != width && width > 0 {
+            self.images.borrow_mut().set_width(self.image_width(width));
             self.rebuild_visual_lines(width);
         }
 
@@ -1048,34 +1109,51 @@ impl Output for Preview {
                 .or_insert_with(|| self.logical_lines[visual_line.logical_idx].render(&ctx));
         }
 
-        let items: Vec<ListItem> = window
-            .iter()
-            .enumerate()
-            .map(|(win_i, visual_line)| {
-                let visual_idx = win_start + win_i;
-                let source_line = rendered_logical
-                    .get(&visual_line.logical_idx)
-                    .expect("visible logical line was rendered");
-                let mut line = self.render_visual_line_from(visual_line, source_line, &ctx);
-                if let Some(term) = self.search.term() {
-                    line = highlight_line(line, term, self.theme.search_highlight_style());
+        let mut items = Vec::with_capacity(window.len());
+        let mut image_rows = Vec::new();
+        for (win_i, visual_line) in window.iter().enumerate() {
+            let visual_idx = win_start + win_i;
+            let logical_idx = visual_line.logical_idx;
+            let logical_line = &self.logical_lines[logical_idx];
+
+            if logical_line.is_image() {
+                // Record the first visible row of each image
+                let first_visible_row = win_i == 0 || window[win_i - 1].logical_idx != logical_idx;
+                if first_visible_row {
+                    let first_global = visual_idx as i32 - visual_line.wrap_idx as i32;
+                    image_rows.push((logical_idx, first_global));
                 }
 
-                if let Some((sel_start, sel_end)) = self
-                    .selection
-                    .range_for_line(visual_idx, line.to_string().chars().count())
-                {
-                    line = SelectionState::apply_range(
-                        line,
-                        sel_start,
-                        sel_end,
-                        self.theme.selection_style(),
-                    );
+                // The image widget paints continuation rows after the list.
+                if visual_line.wrap_idx > 0 {
+                    items.push(ListItem::new(Text::raw("")));
+                    continue;
                 }
+            }
 
-                ListItem::new(Text::from(line))
-            })
-            .collect();
+            let source_line = rendered_logical
+                .get(&logical_idx)
+                .expect("visible logical line was rendered");
+            let mut line = self.render_visual_line_from(visual_line, source_line, &ctx);
+            if let Some(term) = self.search.term() {
+                line = highlight_line(line, term, self.theme.search_highlight_style());
+            }
+
+            if let Some((sel_start, sel_end)) = self
+                .selection
+                .range_for_line(visual_idx, line.to_string().chars().count())
+            {
+                line = SelectionState::apply_range(
+                    line,
+                    sel_start,
+                    sel_end,
+                    self.theme.selection_style(),
+                );
+            }
+
+            items.push(ListItem::new(Text::from(line)));
+        }
+
         if cache_misses > 0 {
             tracing::debug!(
                 visual_rows = window.len(),
@@ -1100,6 +1178,43 @@ impl Output for Preview {
             .padding(Padding::horizontal(1));
 
         frame.render_stateful_widget(List::new(items).block(block), area, &mut render_state);
+
+        self.render_images(frame, area, original_offset, &image_rows);
+    }
+}
+
+impl Preview {
+    /// Draws loaded images over their reserved viewport rows.
+    fn render_images(
+        &self,
+        frame: &mut Frame,
+        area: Rect,
+        original_offset: usize,
+        image_rows: &[(usize, i32)],
+    ) {
+        use ratatui_image::sliced::SignedPosition;
+
+        let images = self.images.borrow();
+        let base_dir = &self.image_base_dir;
+        let content_area = Rect::new(
+            area.x + PREVIEW_CONTENT_X_OFFSET,
+            area.y + PREVIEW_CONTENT_TOP_OFFSET,
+            area.width.saturating_sub(PREVIEW_FRAME_OVERHEAD as u16),
+            area.height.saturating_sub(BORDER_HEIGHT as u16),
+        );
+        for (logical_idx, first_global) in image_rows {
+            let Some(src) = self.logical_lines[*logical_idx].image_src() else {
+                continue;
+            };
+            if images.protocol(src, base_dir).is_none() {
+                continue;
+            }
+            let position = SignedPosition::from((
+                0,
+                i16::try_from(first_global - original_offset as i32).unwrap_or(i16::MIN),
+            ));
+            images.render(frame, src, base_dir, content_area, position);
+        }
     }
 }
 
@@ -1116,7 +1231,28 @@ mod tests {
         let theme = Theme::new("base16-ocean.dark", false);
         let outputs = HashMap::new();
         let keymap: DerivedConfig<Action> = toml::from_str("").unwrap();
-        Preview::new(doc.nodes, doc.codes, theme, &outputs, 10, keymap)
+        Preview::new(
+            doc.nodes,
+            doc.codes,
+            theme,
+            &outputs,
+            10,
+            keymap,
+            std::path::PathBuf::from("."),
+        )
+    }
+
+    #[test]
+    fn image_continuation_rows_have_no_copy_text() {
+        let preview = preview_from_markdown("![alt](image.png)");
+        let row = VisualLine {
+            code_id: None,
+            logical_idx: 0,
+            wrap_idx: 1,
+            char_range: 0..0,
+        };
+
+        assert!(preview.plain_visual_line(&row).to_string().is_empty());
     }
 
     fn render_visual_line(
@@ -1338,7 +1474,15 @@ mod tests {
         output.exit_code = Some(0);
         outputs.insert(1, output);
         let keymap: DerivedConfig<Action> = toml::from_str("").unwrap();
-        let preview = Preview::new(doc.nodes, doc.codes, theme, &outputs, 10, keymap);
+        let preview = Preview::new(
+            doc.nodes,
+            doc.codes,
+            theme,
+            &outputs,
+            10,
+            keymap,
+            std::path::PathBuf::from("."),
+        );
         preview.rebuild_visual_lines(80);
         let code_info = preview
             .logical_lines
@@ -1651,7 +1795,15 @@ mod tests {
         let theme = Theme::new("base16-ocean.dark", false);
         let outputs = std::collections::HashMap::new();
         let keymap: keymap::DerivedConfig<Action> = toml::from_str("").unwrap();
-        let preview = Preview::new(doc.nodes, doc.codes, theme, &outputs, 10, keymap);
+        let preview = Preview::new(
+            doc.nodes,
+            doc.codes,
+            theme,
+            &outputs,
+            10,
+            keymap,
+            std::path::PathBuf::from("."),
+        );
 
         // code block 1 is inside blockquote, code block 2 is flat
         assert!(

--- a/src/apps/tui/preview/visual_lines.rs
+++ b/src/apps/tui/preview/visual_lines.rs
@@ -88,6 +88,7 @@ impl VisualLines {
         theme: &Theme,
         target_block: &Cell<Option<CodeId>>,
         is_code_start_at: impl Fn(usize) -> bool,
+        rows_for: impl Fn(&LogicalLine) -> usize,
     ) -> Option<usize> {
         if width == 0 {
             return None;
@@ -103,6 +104,19 @@ impl VisualLines {
 
         let mut new_visual_lines = Vec::new();
         for (idx, logical_line) in logical_lines.iter().enumerate() {
+            if logical_line.is_image() {
+                // Represent image height as repeated visual rows. Only the
+                // first row carries alt text.
+                for row in 0..rows_for(logical_line).max(1) {
+                    new_visual_lines.push(VisualLine::wrapped(
+                        logical_line.code_id,
+                        idx,
+                        row,
+                        0..0,
+                    ));
+                }
+                continue;
+            }
             let line = logical_line.render_plain(&ctx);
             let prefix_width = logical_line.prefix_width();
             let wrap_width = if logical_line.has_code_gutter() {


### PR DESCRIPTION
## Summary

Render standalone markdown images in the TUI preview using ratatui-image.

- Block images (`![alt](path)` alone in a paragraph) render in the preview (inline images stay styled text)
- Remote (URL) images not yet supported (requires extra deps)

#### Kitty image protocol supported
<img width="544" height="171" alt="image" src="https://github.com/user-attachments/assets/a6ee3306-4f3e-4030-82bc-096880e1591a" />

#### Fallback to halfblock
<img width="539" height="221" alt="image" src="https://github.com/user-attachments/assets/69c79754-79cc-4216-a791-b8ff57b26f4f" />
