### PR TITLE
feat: render raw HTML in the Markdown preview

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -39,6 +39,23 @@ A standalone image renders in the preview pane:
 | Emphasis | **bold**, *italic*, and ***both*** |
 | Other | ~~strikethrough~~, `inline code`, and [link](https://upmd.rezigned.com/) |
 
+### Raw HTML
+
+Inline tags render with HTML syntax highlighting and keep their source text:
+a <b>bold</b> tag, an <em>emphasis</em> tag, a <br/> self-closing tag, and a
+<!-- comment -->.
+
+A complete HTML block is shown verbatim, line by line:
+
+<div class="card">
+  <h3>Example card</h3>
+  <p>HTML blocks keep their attributes and line breaks.</p>
+  <ul>
+    <li>first item</li>
+    <li>second item</li>
+  </ul>
+</div>
+
 ## Streamed output
 
 Output appears inline while the block runs. The preview follows new rows only when they extend below the viewport.

--- a/crates/upmd-parser/src/nodes.rs
+++ b/crates/upmd-parser/src/nodes.rs
@@ -13,6 +13,7 @@ pub enum Node {
     Code(CodeId),
     Table(Table),
     Text(Vec<InlineSpan>),
+    HtmlBlock(String),
     ThematicBreak,
     /// A standalone image paragraph (`![alt](src)` as its only content).
     Image {
@@ -45,11 +46,21 @@ pub enum InlineStyle {
         alt: String,
         src: String,
     },
+    HtmlTag,
 }
 
 /// Concatenates span text into a single plain string (for search, copy, menus).
 pub fn inline_text(spans: &[InlineSpan]) -> String {
     spans.iter().map(|s| s.text.as_str()).collect()
+}
+
+/// Concatenates span text, excluding HTML tags (for semantic labels).
+pub fn semantic_text(spans: &[InlineSpan]) -> String {
+    spans
+        .iter()
+        .filter(|s| !s.style.contains(&InlineStyle::HtmlTag))
+        .map(|s| s.text.as_str())
+        .collect()
 }
 
 /// Heading metadata collected during parsing.

--- a/crates/upmd-parser/src/parser.rs
+++ b/crates/upmd-parser/src/parser.rs
@@ -4,8 +4,8 @@ use pulldown_cmark::{
 };
 
 use super::nodes::{
-    inline_text, Alignment, Codes, InlineSpan, InlineStyle, ListItem, ListKind, Node, Table,
-    TableCell, TaskStatus,
+    inline_text, semantic_text, Alignment, Codes, InlineSpan, InlineStyle, ListItem, ListKind,
+    Node, Table, TableCell, TaskStatus,
 };
 use super::options;
 
@@ -105,6 +105,9 @@ impl<'a> Parser<'a> {
                         nodes.push(node);
                     }
                 }
+                Event::Start(Tag::HtmlBlock) => {
+                    nodes.push(self.parse_html_block());
+                }
                 Event::Start(Tag::Table(alignments)) => {
                     nodes.push(self.parse_table(&alignments));
                 }
@@ -168,7 +171,7 @@ impl<'a> Parser<'a> {
             HeadingLevel::H6 => 6,
         };
         let spans = self.parse_inline_content(TagEnd::Heading(level));
-        let text = inline_text(&spans);
+        let text = semantic_text(&spans);
         let text = text.trim().to_string();
         let spans = trim_spans(spans);
         self.headings.push(super::Heading {
@@ -208,6 +211,22 @@ impl<'a> Parser<'a> {
         let options = options::parse(&opts);
         let code_id = self.codes.push(content, options);
         Some(Node::Code(code_id))
+    }
+
+    // HTML block
+
+    fn parse_html_block(&mut self) -> Node {
+        let mut content = String::new();
+        loop {
+            match self.iter.next() {
+                Some((Event::End(TagEnd::HtmlBlock), _)) => break,
+                Some((Event::Html(html), _)) => content.push_str(&html),
+                Some((Event::Text(text), _)) => content.push_str(&text),
+                None => break,
+                _ => {}
+            }
+        }
+        Node::HtmlBlock(content)
     }
 
     // Table
@@ -301,6 +320,9 @@ impl<'a> Parser<'a> {
                         children.push(node);
                     }
                 }
+                Event::Start(Tag::HtmlBlock) => {
+                    children.push(self.parse_html_block());
+                }
                 Event::Start(Tag::List(start)) => {
                     children.push(Node::List(self.parse_list(depth + 1, start)));
                 }
@@ -359,6 +381,7 @@ impl<'a> Parser<'a> {
         match event {
             Event::Text(text) => out.push(text_span(text.into_string(), stack)),
             Event::Code(code) => out.push(code_span(&code, stack)),
+            Event::InlineHtml(tag) => out.push(html_span(&tag, stack)),
             Event::SoftBreak | Event::HardBreak => out.push(break_span(stack)),
             Event::Start(Tag::Emphasis) => {
                 self.parse_styled_until(InlineStyle::Italic, TagEnd::Emphasis, stack, out);
@@ -476,6 +499,16 @@ fn code_span(code: &str, stack: &[InlineStyle]) -> InlineSpan {
     style.push(InlineStyle::InlineCode);
     InlineSpan {
         text: format!("`{}`", code),
+        style,
+    }
+}
+
+/// Builds a span for an inline HTML tag, preserving its source text.
+fn html_span(html: &str, stack: &[InlineStyle]) -> InlineSpan {
+    let mut style = stack.to_vec();
+    style.push(InlineStyle::HtmlTag);
+    InlineSpan {
+        text: html.to_string(),
         style,
     }
 }
@@ -892,6 +925,31 @@ mod tests {
             assert_eq!(cell.spans.len(), 1, "input: {markdown:?}");
             assert_eq!(cell.spans[0].style, expected_styles, "input: {markdown:?}");
         }
+    }
+
+    #[test]
+    fn test_parse_html() {
+        for (input, expected) in [
+            (
+                "<div class=\"card\">\n<p>Hello</p>\n</div>\n",
+                "<div class=\"card\">\n<p>Hello</p>\n</div>\n",
+            ),
+            ("**bold** <b>tag</b> <br/>", "bold <b>tag</b> <br/>"),
+            ("# Title <b>with tag</b>\n", "Title <b>with tag</b>"),
+        ] {
+            let doc = Cmark::new().parse(input);
+            let text = match &doc.nodes[0] {
+                Node::HtmlBlock(content) => content.clone(),
+                Node::Paragraph(spans) => inline_text(spans),
+                Node::Heading { text, .. } => inline_text(text),
+                other => panic!("Expected {input:?} to start with a text node, got {other:?}"),
+            };
+            assert_eq!(text, expected, "input: {input:?}");
+        }
+
+        // Semantic heading labels exclude HTML tags.
+        let doc = Cmark::new().parse("# Title <b>with tag</b>\n");
+        assert_eq!(doc.headings[0].text, "Title with tag");
     }
 
     #[test]

--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -12,6 +12,7 @@
 
 use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
@@ -78,6 +79,56 @@ impl Default for LazyText {
             spans: Vec::new(),
             cached: std::cell::RefCell::new(None),
         }
+    }
+}
+
+#[derive(Debug)]
+pub struct MarkdownHtml {
+    source: String,
+    lines: Vec<String>,
+    cached: RefCell<Option<Text<'static>>>,
+}
+
+impl MarkdownHtml {
+    fn new(source: String) -> Self {
+        let lines = source.lines().map(str::to_owned).collect();
+        Self {
+            source,
+            lines,
+            cached: RefCell::new(None),
+        }
+    }
+
+    pub(crate) fn source(&self) -> &str {
+        &self.source
+    }
+
+    fn len(&self) -> usize {
+        self.lines.len()
+    }
+
+    fn raw_line(&self, row_idx: usize) -> &str {
+        self.lines.get(row_idx).map_or("", String::as_str)
+    }
+
+    fn line(&self, row_idx: usize, theme: &Theme) -> Line<'static> {
+        let mut cached = self.cached.borrow_mut();
+        if cached.is_none() {
+            let mut rendered = theme.highlight(&self.source, "html");
+            for line in &mut rendered.lines {
+                *line = expand_tabs_in_line(std::mem::take(line));
+            }
+            *cached = Some(rendered);
+        }
+        cached
+            .as_ref()
+            .and_then(|text| text.lines.get(row_idx))
+            .cloned()
+            .unwrap_or_else(|| expand_tabs_in_line(Line::raw(self.raw_line(row_idx).to_owned())))
+    }
+
+    fn clear_cache(&self) {
+        *self.cached.borrow_mut() = None;
     }
 }
 
@@ -150,6 +201,11 @@ pub enum LogicalLineSource {
     CodeInfo(CodeInfoLine),
     CodeBody(LazyText),
     Output(Text<'static>),
+    /// One row of a raw HTML block highlighted and cached as a complete block.
+    Html {
+        block: Rc<MarkdownHtml>,
+        row_idx: usize,
+    },
     TableRow {
         /// Raw table data and responsive render cache shared by every row.
         table: Rc<MarkdownTable>,
@@ -300,6 +356,15 @@ impl LogicalLine {
         }
     }
 
+    /// Creates one row of a raw HTML block.
+    pub fn html(block: Rc<MarkdownHtml>, row_idx: usize, is_block_start: bool) -> Self {
+        Self {
+            source: LogicalLineSource::Html { block, row_idx },
+            is_block_start,
+            ..Self::default()
+        }
+    }
+
     /// Creates a table row or border line.
     pub fn table(table: Rc<MarkdownTable>, row_idx: usize, initial: Line<'static>) -> Self {
         Self {
@@ -333,10 +398,26 @@ impl LogicalLine {
         self.source.lazy_text()
     }
 
+    pub fn html_block(&self) -> Option<&Rc<MarkdownHtml>> {
+        match &self.source {
+            LogicalLineSource::Html { block, .. } => Some(block),
+            _ => None,
+        }
+    }
+
+    pub fn reuse_html_block(&mut self, cached: &Rc<MarkdownHtml>) {
+        if let LogicalLineSource::Html { block, .. } = &mut self.source {
+            if block.source() == cached.source() {
+                *block = Rc::clone(cached);
+            }
+        }
+    }
+
     /// Clears cached content so the next render uses the current theme.
     pub fn clear_cache(&self) {
         match &self.source {
             LogicalLineSource::TableRow { table, .. } => table.clear_cache(),
+            LogicalLineSource::Html { block, .. } => block.clear_cache(),
             _ => {
                 if let Some(text) = self.lazy_text() {
                     *text.cached.borrow_mut() = None;
@@ -421,6 +502,7 @@ impl LogicalLine {
                 format!("{left} {}", info.right.trim_end())
             }
             LogicalLineSource::Output(text) => text.to_string(),
+            LogicalLineSource::Html { block, row_idx } => block.raw_line(*row_idx).to_owned(),
             LogicalLineSource::TableRow { initial, .. } => initial.to_string(),
             LogicalLineSource::Image { alt, .. } => alt.clone(),
             LogicalLineSource::ThematicBreak | LogicalLineSource::Newline => String::new(),
@@ -538,10 +620,15 @@ impl LogicalLine {
 
     /// Renders text-identical content without syntax highlighting.
     fn render_plain_content(&self, ctx: &RenderContext<'_>) -> Line<'static> {
-        if let Some(text) = self.lazy_text() {
-            expand_tabs_in_line(Line::raw(text.text.clone()))
-        } else {
-            self.render_content(ctx)
+        match &self.source {
+            LogicalLineSource::Html { block, row_idx } => {
+                expand_tabs_in_line(Line::raw(block.raw_line(*row_idx).to_owned()))
+            }
+            _ if self.lazy_text().is_some() => {
+                let text = self.lazy_text().expect("checked lazy text");
+                expand_tabs_in_line(Line::raw(text.text.clone()))
+            }
+            _ => self.render_content(ctx),
         }
     }
 
@@ -553,7 +640,7 @@ impl LogicalLine {
             | LogicalLineSource::CodeBody(text)
             | LogicalLineSource::Heading { text, .. } => {
                 let mut cache = text.cached.borrow_mut();
-                if let Some(ref hit) = *cache {
+                if let Some(hit) = &*cache {
                     return hit
                         .lines
                         .first()
@@ -587,6 +674,7 @@ impl LogicalLine {
                 *cache = Some(rendered);
                 line
             }
+            LogicalLineSource::Html { block, row_idx } => block.line(*row_idx, ctx.theme),
             LogicalLineSource::CodeInfo(info) => {
                 let prefix_width = self.prefix_width();
                 let wrap_width = ctx
@@ -957,6 +1045,17 @@ impl<'a> MarkdownRenderer<'a> {
     ) {
         use upmd_parser::nodes::Node;
         match node {
+            Node::HtmlBlock(html) => {
+                let block = Rc::new(MarkdownHtml::new(html.clone()));
+                for row_idx in 0..block.len() {
+                    self.push_line(
+                        lines,
+                        LogicalLine::html(Rc::clone(&block), row_idx, row_idx == 0),
+                        state.quote_depth,
+                    );
+                }
+                self.push_line(lines, LogicalLine::newline(None, false), state.quote_depth);
+            }
             Node::Text(t) => {
                 self.push_highlighted_lines(t, lines, true, state.quote_depth);
             }
@@ -1423,7 +1522,7 @@ fn split_span_lines(spans: &[InlineSpan]) -> Vec<Vec<InlineSpan>> {
 fn render_inline_spans(spans: &[InlineSpan], base_style: Style, theme: &Theme) -> Line<'static> {
     let rendered = spans
         .iter()
-        .map(|span| render_inline_span(span, base_style, theme))
+        .flat_map(|span| render_inline_span(span, base_style, theme))
         .collect::<Vec<_>>();
     Line::from(rendered).style(base_style)
 }
@@ -1434,7 +1533,7 @@ fn render_heading_spans(spans: &[InlineSpan], theme: &Theme) -> Line<'static> {
     let rendered = spans
         .iter()
         .enumerate()
-        .map(|(index, span)| {
+        .flat_map(|(index, span)| {
             let base_style = if index == 0 && span.text.starts_with('#') {
                 theme.markdown_heading_marker_style()
             } else {
@@ -1446,11 +1545,28 @@ fn render_heading_spans(spans: &[InlineSpan], theme: &Theme) -> Line<'static> {
     Line::from(rendered).style(heading_style)
 }
 
-fn render_inline_span(span: &InlineSpan, base_style: Style, theme: &Theme) -> Span<'static> {
+fn render_inline_span(span: &InlineSpan, base_style: Style, theme: &Theme) -> Vec<Span<'static>> {
+    if span.style.iter().any(|s| matches!(s, InlineStyle::HtmlTag)) {
+        return render_html_tag(span, base_style, theme);
+    }
     let style = span.style.iter().fold(base_style, |style, inline| {
         style.patch(inline_style(theme, inline))
     });
-    Span::styled(span.text.clone(), style)
+    vec![Span::styled(span.text.clone(), style)]
+}
+
+/// Highlights an inline HTML tag with the HTML syntax.
+fn render_html_tag(span: &InlineSpan, base_style: Style, theme: &Theme) -> Vec<Span<'static>> {
+    let rendered = theme.highlight(&span.text, "html");
+    let mut spans: Vec<Span<'static>> = rendered
+        .lines
+        .into_iter()
+        .flat_map(|line| line.spans)
+        .collect();
+    if spans.is_empty() {
+        spans.push(Span::styled(span.text.clone(), base_style));
+    }
+    spans
 }
 
 /// Maps an [`InlineStyle`] to the ratatui [`Style`] patched onto a semantic
@@ -1463,6 +1579,7 @@ fn inline_style(theme: &Theme, style: &InlineStyle) -> Style {
         InlineStyle::InlineCode => theme.inline_code_style(),
         InlineStyle::Link { .. } => theme.link_style(),
         InlineStyle::Image { .. } => theme.image_style(),
+        InlineStyle::HtmlTag => Style::default(),
     }
 }
 
@@ -1476,11 +1593,25 @@ mod tests {
     use std::collections::HashMap;
     use upmd_parser::Parser;
 
+    fn test_theme() -> Theme {
+        Theme::new("base16-ocean.dark", false)
+    }
+
+    fn test_ctx(theme: &Theme, width: usize) -> RenderContext<'_> {
+        RenderContext {
+            theme,
+            active_code_id: None,
+            prefer_status_gutter: None,
+            spinner_char: ' ',
+            viewport_width: width,
+        }
+    }
+
     fn render_markdown(markdown: &str) -> RenderedMarkdown {
         let doc = upmd_parser::new().parse(markdown);
         let nodes = &doc.nodes;
         let codes = &doc.codes;
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let outputs = HashMap::new();
         let renderer = MarkdownRenderer::new(&theme, &outputs, codes, 10, 80);
         renderer.render(nodes)
@@ -1493,7 +1624,7 @@ mod tests {
         let doc = upmd_parser::new().parse(markdown);
         let nodes = &doc.nodes;
         let codes = &doc.codes;
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let rendered = {
             let renderer = MarkdownRenderer::new(&theme, outputs, codes, 10, 80);
             renderer.render(nodes)
@@ -1513,6 +1644,7 @@ mod tests {
             LogicalLineSource::CodeInfo(_) => "CodeInfo".to_string(),
             LogicalLineSource::CodeBody(_) => "CodeBody".to_string(),
             LogicalLineSource::Output(_) => "Output".to_string(),
+            LogicalLineSource::Html { .. } => "Html".to_string(),
             LogicalLineSource::TableRow { .. } => "Table".to_string(),
             LogicalLineSource::Image { .. } => "Image".to_string(),
             LogicalLineSource::ThematicBreak => "ThematicBreak".to_string(),
@@ -1633,14 +1765,8 @@ mod tests {
 
     #[test]
     fn test_blockquote_list_item_renders_quote_and_list_prefixes() {
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let lines = render_nodes("> - quoted item");
         let list_item = lines
             .iter()
@@ -1653,7 +1779,7 @@ mod tests {
 
     #[test]
     fn test_apply_gutter_prefers_active_color_without_prefer_status_gutter() {
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let mut line = Line::from("done");
 
         apply_gutter(
@@ -1674,7 +1800,7 @@ mod tests {
 
     #[test]
     fn test_apply_gutter_prefers_status_color_with_prefer_status_gutter() {
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let mut line = Line::from("done");
 
         apply_gutter(
@@ -1779,15 +1905,65 @@ mod tests {
     }
 
     #[test]
+    fn test_render_html_tabs_preserved_logically_expanded_visually() {
+        let lines = render_nodes("<pre>\n\tindented\n</pre>\n");
+        let html: Vec<&LogicalLine> = lines
+            .iter()
+            .filter(|l| matches!(l.source, LogicalLineSource::Html { .. }))
+            .collect();
+        assert_eq!(html.len(), 3);
+        assert_eq!(html[1].text_content(), "\tindented");
+
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
+        let painted = html[1].render(&ctx).to_string();
+        assert!(!painted.contains('\t'));
+        assert!(painted.contains("    indented"));
+        assert_eq!(html[1].render_plain(&ctx).to_string(), painted);
+    }
+
+    #[test]
+    fn test_render_html_styles() {
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
+
+        for (name, line) in [
+            (
+                "block",
+                render_nodes("<div class=\"card\">\n</div>\n")
+                    .iter()
+                    .find(|l| matches!(l.source, LogicalLineSource::Html { .. }))
+                    .unwrap()
+                    .render(&ctx),
+            ),
+            (
+                "inline",
+                render_nodes("x <img src=\"a.png\"> y")
+                    .iter()
+                    .find(|l| matches!(l.source, LogicalLineSource::Text(_)))
+                    .unwrap()
+                    .render(&ctx),
+            ),
+        ] {
+            let mut distinct: Vec<Color> = Vec::new();
+            for span in &line.spans {
+                if let Some(fg) = span.style.fg {
+                    if !distinct.contains(&fg) {
+                        distinct.push(fg);
+                    }
+                }
+            }
+            assert!(
+                distinct.len() >= 2,
+                "{name} HTML should use multiple syntax colors, got {distinct:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_render_inline_heading_styles() {
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let lines = render_nodes("# **Bold** title");
         let heading = lines
             .iter()
@@ -1800,14 +1976,8 @@ mod tests {
 
     #[test]
     fn test_render_inline_list_item_styles() {
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let lines = render_nodes("- **bold item**");
         let item = lines
             .iter()
@@ -1871,14 +2041,8 @@ mod tests {
 
     #[test]
     fn test_render_table_inline_styles() {
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let lines = render_nodes(
             "| Name | Reference |\n\
              |------|-----------|\n\
@@ -1967,14 +2131,8 @@ pytest tests/
             "\tos.Setenv(\"FROM_GO\", \"set by go\")"
         );
 
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let import_line = code_bodies[1].render(&ctx).to_string();
         let call_line = code_bodies[2].render(&ctx).to_string();
 
@@ -2030,17 +2188,11 @@ pytest tests/
     #[test]
     fn test_render_table_narrow() {
         let doc = upmd_parser::new().parse("| Name | Age | City |\n|------|-----|------|\n| Alice | 30 | New York |\n| Bob | 25 | London |");
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 25);
         let outputs = HashMap::new();
         let renderer = MarkdownRenderer::new(&theme, &outputs, &doc.codes, 10, 25);
         let lines = renderer.render(&doc.nodes).lines;
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 25,
-        };
         let summary: Vec<String> = lines
             .iter()
             .filter(|l| l.is_table())
@@ -2052,17 +2204,11 @@ pytest tests/
     #[test]
     fn test_render_table_wide() {
         let doc = upmd_parser::new().parse("| Name | Age | City |\n|------|-----|------|\n| Alice | 30 | New York |\n| Bob | 25 | London |");
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let outputs = HashMap::new();
         let renderer = MarkdownRenderer::new(&theme, &outputs, &doc.codes, 10, 80);
         let lines = renderer.render(&doc.nodes).lines;
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
         let summary: Vec<String> = lines
             .iter()
             .filter(|l| l.is_table())
@@ -2090,7 +2236,7 @@ pytest tests/
         inline_max_lines: usize,
     ) -> String {
         let doc = upmd_parser::new().parse(markdown);
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let renderer = MarkdownRenderer::new(&theme, outputs, &doc.codes, inline_max_lines, 80);
         let lines = renderer.render(&doc.nodes).lines;
         logical_line_summary(&lines)
@@ -2166,14 +2312,8 @@ pytest tests/
 
     #[test]
     fn render_plain_does_not_populate_content_cache() {
-        let theme = Theme::new("base16-ocean.dark", false);
-        let ctx = RenderContext {
-            theme: &theme,
-            active_code_id: None,
-            prefer_status_gutter: None,
-            spinner_char: ' ',
-            viewport_width: 80,
-        };
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
         let line = LogicalLine::text_lazy_spans(
             vec![InlineSpan {
                 text: "let value = 1;".into(),
@@ -2195,7 +2335,7 @@ pytest tests/
 
     #[test]
     fn running_code_body_does_not_append_spinner() {
-        let theme = Theme::new("base16-ocean.dark", false);
+        let theme = test_theme();
         let ctx = RenderContext {
             theme: &theme,
             active_code_id: Some(1),

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -36,6 +36,7 @@ use ratatui::{
 };
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
+use std::rc::Rc;
 
 use crate::apps::config::{
     BORDER_HEIGHT, CODE_GUTTER_WIDTH, INLINE_MAX_LINES_DEFAULT, INLINE_MAX_LINES_FRACTION,
@@ -48,7 +49,9 @@ use keymap::{DerivedConfig, KeyMap};
 use upmd_parser::nodes::Node;
 use upmd_parser::Codes;
 
-use super::markdown::{apply_gutter, highlight_line, LogicalLine, MarkdownRenderer, RenderContext};
+use super::markdown::{
+    apply_gutter, highlight_line, LogicalLine, MarkdownHtml, MarkdownRenderer, RenderContext,
+};
 use super::selection::SelectionState;
 use super::wrap::{slice_line, CopyLine};
 use crate::apps::task::Task;
@@ -247,14 +250,26 @@ impl Preview {
         tracing::Span::current().record("lines", rendered.lines.len());
         self.logical_lines = rendered.lines;
         self.code_prefix_overhead = rendered.code_prefix_overhead;
-        // Preserve lazy syntax highlighting caches for unchanged source lines.
+
+        // Reuse caches from the previous render for unchanged lines. HTML
+        // blocks are reused by whole-block source; other lines match on text.
+        let old_html: HashMap<String, Rc<MarkdownHtml>> = old_lines
+            .iter()
+            .filter_map(LogicalLine::html_block)
+            .map(|block| (block.source().to_owned(), Rc::clone(block)))
+            .collect();
         let mut old_raw_iter = old_lines
             .into_iter()
             .filter_map(LogicalLine::into_lazy_text)
             .peekable();
 
-        // Match new source lines sequentially so unchanged text keeps its cache.
         for line in &mut self.logical_lines {
+            if let Some(block) = line.html_block() {
+                if let Some(cached) = old_html.get(block.source()) {
+                    line.reuse_html_block(cached);
+                }
+                continue;
+            }
             let Some(text) = line.lazy_text_mut() else {
                 continue;
             };
@@ -1240,6 +1255,45 @@ mod tests {
             keymap,
             std::path::PathBuf::from("."),
         )
+    }
+
+    #[test]
+    fn html_block_cache_rebuilds() {
+        let comment = "<!--\ninside comment\n-->\n";
+        let div = "<div>\ninside element\n</div>\n";
+        let block = |p: &Preview| {
+            Rc::clone(
+                p.logical_lines
+                    .iter()
+                    .find_map(LogicalLine::html_block)
+                    .expect("HTML block"),
+            )
+        };
+
+        for (name, updated, change_theme, expect_reuse) in [
+            ("unchanged", comment, false, true),
+            ("theme changed", comment, true, true),
+            ("source changed", div, false, false),
+        ] {
+            let mut preview = preview_from_markdown(comment);
+            let before = block(&preview);
+
+            if change_theme {
+                preview.set_theme(&Theme::new("base16-ocean.dark", true));
+            }
+            if updated != comment {
+                let doc = upmd_parser::new().parse(updated);
+                preview.nodes = doc.nodes;
+                preview.code_index = doc.codes;
+            }
+            preview.rebuild_view(&HashMap::new());
+
+            assert_eq!(
+                Rc::ptr_eq(&before, &block(&preview)),
+                expect_reuse,
+                "{name}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Render raw HTML in the TUI preview with syntax highlighting.

- HTML blocks and inline tags render verbatim where they appear, preserving text for wrapping, selection, search, and copy
- Block HTML is highlighted once per block, preserving syntax state across lines, with a cache reused across rebuilds