### PR TITLE
fix(tui): render blockquote prefixes consistently

### DIFF
--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -341,6 +341,9 @@ pub struct LogicalLine {
     /// Multiple prefixes can stack (for example, a blockquote marker followed by
     /// a list marker). Keeping them separate preserves each prefix's style.
     pub prefixes: Vec<Span<'static>>,
+    /// Number of leading rendered characters repeated on wrapped rows, such as
+    /// `▎ ` in Visual mode or `> ` in Markup mode.
+    wrap_prefix_width: usize,
     /// Optional foreground color override for the gutter indicator (used by
     /// output lines to reflect task status).
     pub gutter_fg: Option<Color>,
@@ -397,7 +400,9 @@ impl LogicalLine {
 
     /// Creates a markup-mode text line, syntax-highlighted as markdown source.
     pub fn markup_text(text: impl Into<String>, is_block_start: bool) -> Self {
+        let text = text.into();
         Self {
+            wrap_prefix_width: source_quote_width(&text),
             source: LogicalLineSource::Text(LazyText::markdown(text)),
             is_block_start,
             ..Self::default()
@@ -531,6 +536,14 @@ impl LogicalLine {
             .sum()
     }
 
+    pub fn wrap_prefix_width(&self) -> usize {
+        self.wrap_prefix_width
+    }
+
+    pub fn reserved_prefix_width(&self) -> usize {
+        self.prefix_width().max(self.wrap_prefix_width)
+    }
+
     #[inline]
     pub fn heading_level(&self) -> Option<u8> {
         match self.source {
@@ -585,7 +598,11 @@ impl LogicalLine {
     /// Returns `true` for lines that must not be wrapped (already sized/formatted).
     #[inline]
     pub fn is_unwrappable(&self) -> bool {
-        self.is_table() || self.is_output() || self.is_code_info() || self.is_image()
+        self.is_table()
+            || self.is_output()
+            || self.is_code_info()
+            || self.is_image()
+            || matches!(self.source, LogicalLineSource::ThematicBreak)
     }
 
     /// Returns text content, preferring raw text if available.
@@ -1077,7 +1094,7 @@ impl SnapContext {
 struct RenderState {
     /// Snap targets are scoped separately from visual nesting.
     snap: SnapContext,
-    /// Current blockquote nesting depth. Each level adds a display-only "> ".
+    /// Current blockquote nesting depth. Each level adds a display-only gutter.
     quote_depth: usize,
     /// Extra display width before code content, keyed by code block.
     code_prefix_overhead: HashMap<CodeId, usize>,
@@ -1172,9 +1189,9 @@ impl<'a> MarkdownRenderer<'a> {
             }
             None => false,
         };
-        let quote_overhead = Self::quote_prefix_width(state.quote_depth);
-        if quote_overhead > 0 {
-            state.code_prefix_overhead.insert(code.id, quote_overhead);
+        let gutter_width = Self::quote_prefix_width(state.quote_depth);
+        if gutter_width > 0 {
+            state.code_prefix_overhead.insert(code.id, gutter_width);
         }
         let is_running = self.outputs.get(&code.id).is_some_and(|t| t.running());
         let gutter_fg = self.outputs.get(&code.id).and_then(|buffer| {
@@ -1195,11 +1212,15 @@ impl<'a> MarkdownRenderer<'a> {
     }
 
     fn quote_prefix_span(&self) -> Span<'static> {
-        // Quote markers sit outside code backgrounds. Pinning the background
+        // Quote prefixes sit outside code backgrounds. Pinning the background
         // avoids inheriting the highlighted/code block background that is added
         // later during LogicalLine::render.
+        let content = match self.mode {
+            RenderMode::Visual => "▎ ",
+            RenderMode::Markup => "> ",
+        };
         Span::styled(
-            "> ",
+            content,
             Style::default()
                 .fg(self.theme.muted)
                 .bg(self.theme.background),
@@ -1211,9 +1232,9 @@ impl<'a> MarkdownRenderer<'a> {
     }
 
     fn push_line(&self, lines: &mut Vec<LogicalLine>, mut line: LogicalLine, state: &RenderState) {
-        // Quote prefixes are outer chrome. Insert before any existing list/task
-        // prefix so rendering preserves markdown order: "> • item", not
-        // "• > item".
+        // Quote prefixes are outer chrome. Insert them before existing list/task
+        // prefixes so rendering preserves Markdown nesting order.
+        line.wrap_prefix_width = Self::quote_prefix_width(state.quote_depth);
         for _ in 0..state.quote_depth {
             line.prefixes.insert(0, self.quote_prefix_span());
         }
@@ -1590,6 +1611,32 @@ fn inline_style(theme: &Theme, style: &InlineStyle) -> Style {
         InlineStyle::Image { .. } => theme.image_style(),
         InlineStyle::HtmlTag => Style::default(),
     }
+}
+
+/// Returns the byte width of the leading `> ` quote markers in source text.
+fn source_quote_width(text: &str) -> usize {
+    // CommonMark permits up to three spaces before a blockquote marker.
+    const MAX_MARKER_INDENT: usize = 3;
+    let bytes = text.as_bytes();
+    let mut pos = 0;
+    let mut end = 0;
+
+    loop {
+        let spaces = bytes[pos..]
+            .iter()
+            .take(MAX_MARKER_INDENT)
+            .take_while(|&&b| b == b' ')
+            .count();
+        if bytes.get(pos + spaces) != Some(&b'>') {
+            break;
+        }
+        pos += spaces + 1; // consume leading spaces + '>'
+        if bytes.get(pos).is_some_and(|b| matches!(b, b' ' | b'\t')) {
+            pos += 1; // consume one optional space/tab after '>'
+        }
+        end = pos;
+    }
+    end
 }
 
 #[cfg(test)]

--- a/src/apps/tui/markdown/visual.rs
+++ b/src/apps/tui/markdown/visual.rs
@@ -408,7 +408,7 @@ mod tests {
             .expect("expected a list item inside the blockquote");
 
         assert_eq!(list_item.prefix_width(), 4);
-        assert_eq!(list_item.render(&ctx).to_string(), "> • quoted item");
+        assert_eq!(list_item.render(&ctx).to_string(), "▎ • quoted item");
     }
 
     #[test]

--- a/src/apps/tui/preview/layout_lines.rs
+++ b/src/apps/tui/preview/layout_lines.rs
@@ -27,6 +27,10 @@ impl LayoutLine {
         }
     }
 
+    pub fn is_continuation(&self) -> bool {
+        self.wrap_idx > 0
+    }
+
     pub fn logical<'a>(&self, logical_lines: &'a [LogicalLine]) -> &'a LogicalLine {
         &logical_lines[self.logical_idx]
     }
@@ -40,14 +44,16 @@ impl LayoutLine {
         logical_line: &LogicalLine,
         ctx: &RenderContext<'_>,
     ) -> ratatui::text::Line<'static> {
-        if logical_line.is_image() && self.wrap_idx > 0 {
+        if logical_line.is_image() && self.is_continuation() {
             return ratatui::text::Line::raw("");
         }
         let source = logical_line.render_plain(ctx);
         if logical_line.is_unwrappable() {
             source
         } else {
-            slice_line(&source, self.char_range.clone())
+            let mut line = slice_line(&source, self.char_range.clone());
+            self.prepend_wrap_prefix(logical_line, &source, &mut line);
+            line
         }
     }
 
@@ -59,7 +65,7 @@ impl LayoutLine {
         rendered_line: &ratatui::text::Line<'static>,
         ctx: &RenderContext<'_>,
     ) -> ratatui::text::Line<'static> {
-        if logical_line.is_image() && self.wrap_idx > 0 {
+        if logical_line.is_image() && self.is_continuation() {
             return ratatui::text::Line::raw("");
         }
         let mut line = if logical_line.is_unwrappable() {
@@ -67,7 +73,7 @@ impl LayoutLine {
         } else {
             slice_line(rendered_line, self.char_range.clone())
         };
-        if logical_line.has_code_gutter() && self.wrap_idx > 0 {
+        if logical_line.has_code_gutter() && self.is_continuation() {
             apply_gutter(
                 &mut line,
                 logical_line.is_unwrappable(),
@@ -78,7 +84,22 @@ impl LayoutLine {
                 logical_line.gutter_fg == Some(ctx.theme.warning),
             );
         }
+        self.prepend_wrap_prefix(logical_line, rendered_line, &mut line);
         line
+    }
+
+    fn prepend_wrap_prefix(
+        &self,
+        logical_line: &LogicalLine,
+        rendered_line: &ratatui::text::Line<'static>,
+        line: &mut ratatui::text::Line<'static>,
+    ) {
+        if !self.is_continuation() {
+            return;
+        }
+        let width = logical_line.wrap_prefix_width();
+        let prefix = slice_line(rendered_line, 0..width).spans;
+        line.spans.splice(0..0, prefix);
     }
 }
 
@@ -151,7 +172,7 @@ impl LayoutLines {
                 PREVIEW_FRAME_OVERHEAD
             };
             let wrap_width = width
-                .saturating_sub(overhead + logical_line.prefix_width())
+                .saturating_sub(overhead + logical_line.reserved_prefix_width())
                 .max(1);
             let rows = wrap_ranges(&line, wrap_width)
                 .into_iter()

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -218,7 +218,7 @@ impl Preview {
         let mut images = self.images.borrow_mut();
         for src in layout_lines[start..end]
             .iter()
-            .filter(|line| line.wrap_idx == 0)
+            .filter(|line| !line.is_continuation())
             .filter_map(|line| self.logical_lines[line.logical_idx].image_src())
         {
             images.request(src, &self.image_base_dir);
@@ -740,7 +740,7 @@ impl Preview {
         Some((col, pty_row as u16))
     }
 
-    /// Returns the prefix overhead in chars for a code block (e.g. 2 for "> " inside a blockquote).
+    /// Returns the gutter overhead in chars for a code block nested in a blockquote.
     pub fn code_prefix_overhead(&self, id: CodeId) -> usize {
         self.code_prefix_overhead.get(&id).copied().unwrap_or(0)
     }
@@ -772,7 +772,7 @@ impl Preview {
                 text = stripped.to_string();
                 CODE_GUTTER_WIDTH
             }
-            (true, None) if line.wrap_idx > 0 => CODE_GUTTER_WIDTH,
+            (true, None) if line.is_continuation() => CODE_GUTTER_WIDTH,
             _ => 0,
         };
         Some(CopyLine {
@@ -1341,7 +1341,13 @@ mod tests {
 
     #[test]
     fn mode_toggle_switches_to_markup_and_preserves_code_selection() {
-        let mut preview = preview_from_markdown("# Title\n\n```bash\necho hello\n```");
+        let markdown = r#"# Title
+[**bold** text](url "title")
+
+> ```bash
+> echo hello
+> ```"#;
+        let mut preview = preview_from_markdown(markdown);
         preview.rebuild_layout_lines(60);
         preview.select_code(1);
 
@@ -1352,7 +1358,12 @@ mod tests {
         assert_eq!(preview.selected_code_id(), Some(1));
         let text = full_preview_text(&preview);
         assert!(text.contains("# Title"), "got: {text}");
+        assert!(
+            text.contains("[**bold** text](url \"title\")"),
+            "got: {text}"
+        );
         assert!(text.contains("echo hello"), "got: {text}");
+        assert!(!text.contains("> >"), "got: {text}");
     }
 
     #[test]
@@ -1480,7 +1491,12 @@ mod tests {
             .layout_lines
             .borrow()
             .iter()
-            .map(|vl| render_layout_line(preview, vl, &ctx).to_string())
+            .map(|line| {
+                render_layout_line(preview, line, &ctx)
+                    .to_string()
+                    .trim_end_matches(' ')
+                    .to_owned()
+            })
             .collect::<Vec<_>>()
             .join("\n")
     }
@@ -1535,9 +1551,38 @@ mod tests {
     }
 
     #[test]
+    fn markup_nested_code_retains_quote_marker() {
+        let mut preview = preview_from_markdown(
+            r#"> 2. Another ordered item
+>
+> ```bash
+> echo \"code inside a blockquote\"
+> ```"#,
+        );
+        preview.toggle_mode();
+        preview.rebuild_view(&HashMap::new());
+        preview.rebuild_layout_lines(80);
+        let rows = full_preview_text(&preview);
+        let code_rows = rows
+            .lines()
+            .filter(|line| line.contains("Bash") || line.contains("echo"))
+            .collect::<Vec<_>>();
+
+        assert_eq!(code_rows.len(), 2, "got: {rows}");
+        assert!(
+            code_rows.iter().all(|line| line.starts_with("> ▎ ")),
+            "interactive code rows should retain the Markup quote marker, got: {rows}"
+        );
+    }
+
+    #[test]
     fn snapshot_full_table() {
-        let preview =
-            preview_from_markdown("| Name | Age |\n|------|-----|\n| Alice | 30 |\n| Bob | 25 |");
+        let preview = preview_from_markdown(
+            r#"| Name | Age |
+|------|-----|
+| Alice | 30 |
+| Bob | 25 |"#,
+        );
         preview.rebuild_layout_lines(60);
         assert_snapshot!("full_table", full_preview_text(&preview));
     }
@@ -1659,7 +1704,7 @@ mod tests {
         let code_body_line = layout_lines
             .iter()
             .find(|line| {
-                line.wrap_idx == 0
+                !line.is_continuation()
                     && line.code_id(&preview.logical_lines) == Some(1)
                     && line.logical(&preview.logical_lines).is_code_body()
             })
@@ -1711,7 +1756,7 @@ mod tests {
             .borrow()
             .iter()
             .find(|line| {
-                line.wrap_idx == 0
+                !line.is_continuation()
                     && line.code_id(&preview.logical_lines) == Some(1)
                     && line.logical(&preview.logical_lines).is_code_body()
             })

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_blockquote.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_blockquote.snap
@@ -1,10 +1,9 @@
 ---
 source: src/apps/tui/preview/mod.rs
-assertion_line: 1191
 expression: full_preview_text(&preview)
 ---
-> quoted paragraph
-> 
-> ▎ 1                                              Bash 
-> ▎ echo hi
->
+▎ quoted paragraph
+▎
+▎ ▎ 1                                              Bash
+▎ ▎ echo hi
+▎

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_code_wrap.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_code_wrap.snap
@@ -1,9 +1,8 @@
 ---
 source: src/apps/tui/preview/mod.rs
-assertion_line: 1170
 expression: full_preview_text(&preview)
 ---
-▎ 1                  Rust 
+▎ 1                  Rust
 ▎ fn very_long_function_
 ▎ name_that_exceeds_narrow
 ▎ _width() -> VeryLongRetu

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_fenced_code.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_fenced_code.snap
@@ -1,7 +1,6 @@
 ---
 source: src/apps/tui/preview/mod.rs
-assertion_line: 1163
 expression: full_preview_text(&preview)
 ---
-▎ 1                                                Bash 
+▎ 1                                                Bash
 ▎ echo hello

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_mixed_runbook.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_mixed_runbook.snap
@@ -6,10 +6,10 @@ expression: full_preview_text(&preview)
 ────────────────────────────────────
 Install deps.
 
-▎ 1                            Bash 
+▎ 1                            Bash
 ▎ npm install
 
-> note
-> 
+▎ note
+▎
 • a
 • b


### PR DESCRIPTION
## Summary

 Fixes inconsistent blockquote prefix rendering when lines wrap to multiple terminal rows.

 - Repeats the quote gutter (`▎`) on wrapped continuation rows in Visual mode, and `> ` in Markup mode
 - Tracks source quote-marker width per logical line so wrapped rows align with the first row
 - Switches Visual-mode blockquote marker from `> ` to` ▎` , matching the code/table gutter style
 - Treats thematic breaks as unwrappable to avoid spurious wrapping
 
<img width="404" height="436" alt="image" src="https://github.com/user-attachments/assets/cb59fd24-3d9a-4bdb-99c5-ba35058d7b82" />
