### PR TITLE
fix(tui): preserve indentation of nested list blocks

### DIFF
--- a/crates/upmd-parser/src/nodes.rs
+++ b/crates/upmd-parser/src/nodes.rs
@@ -139,8 +139,6 @@ pub struct Heading {
     pub level: u8,
     pub text: String,
     pub source_range: Range<usize>,
-    pub start_line: usize,
-    pub end_line: usize,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -157,12 +155,12 @@ pub enum ListKind {
     Task(TaskStatus),
 }
 
-/// A single list entry with depth, kind, text, and nested children.
+/// A single list entry whose child blocks are stored in source order.
 #[derive(Debug, Clone)]
 pub struct ListItem {
     pub depth: usize,
     pub kind: ListKind,
-    pub text: Vec<InlineSpan>,
+    pub range: Range<usize>,
     pub children: Vec<Node>,
 }
 

--- a/crates/upmd-parser/src/parser.rs
+++ b/crates/upmd-parser/src/parser.rs
@@ -1,3 +1,5 @@
+use std::ops::Range;
+
 use pulldown_cmark::{
     Alignment as CmarkAlignment, CodeBlockKind, Event, HeadingLevel, MetadataBlockKind, Options,
     Parser as CmarkParser, Tag, TagEnd,
@@ -42,7 +44,6 @@ struct ParseState<'a> {
     iter: std::iter::Peekable<pulldown_cmark::OffsetIter<'a>>,
     codes: Codes,
     headings: Vec<super::Heading>,
-    line_starts: Vec<usize>,
 }
 
 impl<'a> ParseState<'a> {
@@ -54,7 +55,6 @@ impl<'a> ParseState<'a> {
                 .peekable(),
             codes: Codes::default(),
             headings: Vec::new(),
-            line_starts: line_starts(source),
         }
     }
 }
@@ -75,38 +75,28 @@ impl ParseState<'_> {
     }
 }
 
-fn line_starts(input: &str) -> Vec<usize> {
-    std::iter::once(0)
-        .chain(input.match_indices('\n').map(|(i, _)| i + 1))
-        .collect()
-}
-
-fn byte_to_line(line_starts: &[usize], byte: usize) -> usize {
-    match line_starts.binary_search(&byte) {
-        Ok(idx) => idx + 1,
-        Err(idx) => idx,
-    }
-    .max(1)
-}
+// Document    ::= Frontmatter? Blocks
+// Frontmatter ::= Text+
+// Frontmatter is recognized only as the first source construct.
 
 impl<'a> ParseState<'a> {
     fn parse_nodes(&mut self) -> Vec<Node> {
-        let frontmatter = match self.iter.peek() {
-            Some((Event::Start(Tag::MetadataBlock(kind)), range)) if range.start == 0 => {
-                Some((*kind, range.clone()))
-            }
-            _ => None,
-        }
-        .map(|(kind, range)| Node::new(self.parse_frontmatter(kind), range));
-
-        let mut nodes = self.parse_blocks(None);
+        let frontmatter = self.parse_frontmatter();
+        let mut nodes = self.parse_blocks();
         if let Some(frontmatter) = frontmatter {
             nodes.insert(0, frontmatter);
         }
         nodes
     }
 
-    fn parse_frontmatter(&mut self, kind: MetadataBlockKind) -> NodeKind {
+    fn parse_frontmatter(&mut self) -> Option<Node> {
+        let (kind, range) = match self.iter.peek() {
+            Some((Event::Start(Tag::MetadataBlock(kind)), range)) if range.start == 0 => {
+                (*kind, range.clone())
+            }
+            _ => return None,
+        };
+
         self.iter.next();
         let mut payload = None;
         for (event, range) in self.iter.by_ref() {
@@ -121,54 +111,64 @@ impl<'a> ParseState<'a> {
             MetadataBlockKind::PlusesStyle => FrontmatterStyle::Toml,
         };
         let raw = SourceText::Source(payload.expect("metadata block has content"));
-        NodeKind::Frontmatter { style, raw }
+        Some(Node::new(NodeKind::Frontmatter { style, raw }, range))
     }
 
-    // Root dispatch
+    // Block container
     //
-    // Blocks ::= (Paragraph | Heading | CodeBlock | Table | List | BlockQuote
-    //             | ThematicBreak | Text)*
+    // Blocks     ::= Block*
+    // Block      ::= Paragraph | Heading | CodeBlock | HtmlBlock | Table | List
+    //                | BlockQuote | ThematicBreak | ImageBlock | Text
+    // BlockQuote ::= Blocks
 
-    fn parse_blocks(&mut self, stop_at: Option<TagEnd>) -> Vec<Node> {
+    fn parse_blocks(&mut self) -> Vec<Node> {
         let mut nodes = Vec::new();
         while let Some((event, range)) = self.iter.next() {
-            if let Some(ref stop) = stop_at {
-                if matches!(&event, Event::End(tag) if *tag == *stop) {
-                    break;
-                }
+            if matches!(event, Event::End(_)) {
+                break;
             }
-            let kind = match event {
-                Event::End(_) => None,
-                Event::Start(Tag::Paragraph) => Some(self.parse_paragraph()),
-                Event::Start(Tag::Heading { level, .. }) => {
-                    Some(self.parse_heading(level, range.clone()))
-                }
-                Event::Start(Tag::List(start)) => Some(NodeKind::List(self.parse_list(1, start))),
-                Event::Start(Tag::BlockQuote(_)) => Some(NodeKind::BlockQuote(
-                    self.parse_blocks(Some(TagEnd::BlockQuote(None))),
-                )),
-                Event::Start(Tag::CodeBlock(kind)) => self.parse_code_block(kind),
-                Event::Start(Tag::HtmlBlock) => Some(self.parse_html_block()),
-                Event::Start(Tag::Table(alignments)) => Some(self.parse_table(&alignments)),
-                Event::Rule => Some(NodeKind::ThematicBreak),
-                Event::Text(text) => Some(NodeKind::Text(vec![text_span(
-                    self.source,
-                    range.clone(),
-                    &text,
-                    &[],
-                )])),
-                Event::Code(code) => Some(NodeKind::Text(vec![code_span(&code, &[])])),
-                _ => None,
-            };
-            if let Some(kind) = kind {
+            if let Some(kind) = self.parse_block_event(event, range.clone(), 1) {
                 nodes.push(Node::new(kind, range));
             }
         }
         nodes
     }
 
-    // Paragraph
+    fn parse_block_event(
+        &mut self,
+        event: Event<'a>,
+        range: Range<usize>,
+        list_depth: usize,
+    ) -> Option<NodeKind> {
+        match event {
+            Event::Start(Tag::Paragraph) => Some(self.parse_paragraph()),
+            Event::Start(Tag::Heading { level, .. }) => {
+                Some(self.parse_heading(level, range.clone()))
+            }
+            Event::Start(Tag::List(start)) => {
+                Some(NodeKind::List(self.parse_list(list_depth, start)))
+            }
+            Event::Start(Tag::BlockQuote(_)) => Some(NodeKind::BlockQuote(self.parse_blocks())),
+            Event::Start(Tag::CodeBlock(kind)) => self.parse_code_block(kind),
+            Event::Start(Tag::HtmlBlock) => Some(self.parse_html_block()),
+            Event::Start(Tag::Table(alignments)) => Some(self.parse_table(&alignments)),
+            Event::Rule => Some(NodeKind::ThematicBreak),
+            Event::Text(text) => Some(NodeKind::Text(vec![text_span(
+                self.source,
+                range,
+                &text,
+                &[],
+            )])),
+            Event::Code(code) => Some(NodeKind::Text(vec![code_span(&code, &[])])),
+            _ => None,
+        }
+    }
 
+    // Paragraph
+    //
+    // Paragraph  ::= InlineContent
+    // ImageBlock ::= Image
+    // A paragraph containing only one image is normalized to ImageBlock.
     fn parse_paragraph(&mut self) -> NodeKind {
         if matches!(self.iter.peek(), Some((Event::Start(Tag::Image { .. }), _))) {
             return self.parse_block_image();
@@ -202,39 +202,25 @@ impl<'a> ParseState<'a> {
     }
 
     // Heading
-
-    fn parse_heading(
-        &mut self,
-        level: HeadingLevel,
-        source_range: std::ops::Range<usize>,
-    ) -> NodeKind {
-        let heading_level = match level {
-            HeadingLevel::H1 => 1,
-            HeadingLevel::H2 => 2,
-            HeadingLevel::H3 => 3,
-            HeadingLevel::H4 => 4,
-            HeadingLevel::H5 => 5,
-            HeadingLevel::H6 => 6,
-        };
+    //
+    // Heading ::= InlineContent
+    fn parse_heading(&mut self, level: HeadingLevel, source_range: Range<usize>) -> NodeKind {
         let spans = self.parse_inline_content(TagEnd::Heading(level));
-        let text = semantic_text(&spans, self.source);
-        let text = text.trim().to_string();
+        let text = semantic_text(&spans, self.source).trim().to_string();
         let spans = trim_spans(spans, self.source);
+        let level = level as u8;
         self.headings.push(super::Heading {
-            level: heading_level,
+            level,
             text: text.clone(),
-            source_range: source_range.clone(),
-            start_line: byte_to_line(&self.line_starts, source_range.start),
-            end_line: byte_to_line(&self.line_starts, source_range.end.max(1) - 1),
+            source_range,
         });
-        NodeKind::Heading {
-            level: heading_level,
-            text: spans,
-        }
+        NodeKind::Heading { level, text: spans }
     }
 
     // Code block
-
+    //
+    // CodeBlock ::= (Text | Break)*
+    // Empty code blocks do not produce a node.
     fn parse_code_block(&mut self, kind: CodeBlockKind<'a>) -> Option<NodeKind> {
         let opts = match &kind {
             CodeBlockKind::Fenced(info) => info.to_string(),
@@ -260,7 +246,8 @@ impl<'a> ParseState<'a> {
     }
 
     // HTML block
-
+    //
+    // HtmlBlock ::= Html*
     fn parse_html_block(&mut self) -> NodeKind {
         for (event, _) in self.iter.by_ref() {
             if matches!(event, Event::End(TagEnd::HtmlBlock)) {
@@ -271,7 +258,11 @@ impl<'a> ParseState<'a> {
     }
 
     // Table
-
+    //
+    // Table     ::= TableHead TableRow*
+    // TableHead ::= TableCell*
+    // TableRow  ::= TableCell*
+    // TableCell ::= InlineContent
     fn parse_table(&mut self, alignments: &[CmarkAlignment]) -> NodeKind {
         let mapped: Vec<Alignment> = alignments.iter().map(Self::map_alignment).collect();
         let mut headers = Vec::new();
@@ -321,16 +312,18 @@ impl<'a> ParseState<'a> {
 
     // List
     //
-    // List       ::= Item+
-    // ListItem   ::= (TaskMarker? InlineContent BlockChildren*)
+    // List     ::= ListItem+
+    // ListItem ::= Block*
+    // Tight inline content is normalized to a Paragraph child. A leading task
+    // marker sets ListKind and is omitted from that paragraph's content.
 
     fn parse_list(&mut self, depth: usize, start_num: Option<u64>) -> Vec<ListItem> {
         let mut items = Vec::new();
         loop {
             match self.iter.next() {
                 Some((Event::End(TagEnd::List(_)), _)) => break,
-                Some((Event::Start(Tag::Item), _)) => {
-                    items.push(self.parse_list_item(depth, items.len(), start_num));
+                Some((Event::Start(Tag::Item), range)) => {
+                    items.push(self.parse_list_item(depth, items.len(), start_num, range));
                 }
                 None => break,
                 _ => {}
@@ -339,54 +332,55 @@ impl<'a> ParseState<'a> {
         items
     }
 
-    fn parse_list_item(&mut self, depth: usize, index: usize, start_num: Option<u64>) -> ListItem {
-        let mut spans = Vec::new();
-        let mut stack = Vec::new();
+    fn parse_list_item(
+        &mut self,
+        depth: usize,
+        index: usize,
+        start_num: Option<u64>,
+        item_range: Range<usize>,
+    ) -> ListItem {
         let mut children = Vec::new();
         let mut task_kind: Option<ListKind> = None;
+        // A tight-list item such as `- item` emits bare inline events; a loose
+        // item separated by blank lines emits a `Paragraph` container. Collect
+        // the tight item's implicit paragraph separately.
+        let mut tight_spans = Vec::new();
+        let mut tight_range: Option<Range<usize>> = None;
+        let mut stack = Vec::new();
 
         while let Some((event, range)) = self.iter.next() {
             let Some(event) =
-                self.consume_inline_event(event, range.clone(), &mut stack, &mut spans)
+                self.consume_inline_event(event, range.clone(), &mut stack, &mut tight_spans)
             else {
+                tight_range.get_or_insert_with(|| range.clone()).end = range.end;
                 continue;
             };
-
             match event {
                 Event::End(TagEnd::Item) => break,
-                Event::TaskListMarker(checked) => {
-                    task_kind = Some(ListKind::Task(if checked {
-                        TaskStatus::Checked
-                    } else {
-                        TaskStatus::Unchecked
-                    }));
+                Event::Start(Tag::Paragraph) => {
+                    if let Some(kind) = self.take_task_marker() {
+                        task_kind = Some(kind);
+                    }
+                    let paragraph =
+                        trim_spans(self.parse_inline_content(TagEnd::Paragraph), self.source);
+                    children.push(Node::new(NodeKind::Paragraph(paragraph), range));
                 }
-                Event::Start(Tag::CodeBlock(kind)) => {
-                    if let Some(kind) = self.parse_code_block(kind) {
+                Event::TaskListMarker(checked) => {
+                    task_kind = Some(task_list_kind(checked));
+                }
+                event => {
+                    if let Some(kind) = self.parse_block_event(event, range.clone(), depth + 1) {
                         children.push(Node::new(kind, range));
                     }
                 }
-                Event::Start(Tag::HtmlBlock) => {
-                    children.push(Node::new(self.parse_html_block(), range));
-                }
-                Event::Start(Tag::List(start)) => {
-                    let kind = NodeKind::List(self.parse_list(depth + 1, start));
-                    children.push(Node::new(kind, range));
-                }
-                Event::Start(Tag::BlockQuote(_)) => {
-                    let kind =
-                        NodeKind::BlockQuote(self.parse_blocks(Some(TagEnd::BlockQuote(None))));
-                    children.push(Node::new(kind, range));
-                }
-                Event::Start(Tag::Table(alignments)) => {
-                    children.push(Node::new(self.parse_table(&alignments), range));
-                }
-                Event::Start(Tag::Heading { level, .. }) => {
-                    let kind = self.parse_heading(level, range.clone());
-                    children.push(Node::new(kind, range));
-                }
-                Event::Start(Tag::Paragraph) => {}
-                _ => {}
+            }
+        }
+
+        if let Some(range) = tight_range {
+            let paragraph = trim_spans(tight_spans, self.source);
+            if !paragraph.is_empty() {
+                let index = children.partition_point(|child| child.range.start < range.start);
+                children.insert(index, Node::new(NodeKind::Paragraph(paragraph), range));
             }
         }
 
@@ -401,15 +395,31 @@ impl<'a> ParseState<'a> {
         ListItem {
             depth,
             kind,
-            text: trim_spans(spans, self.source),
+            range: item_range,
             children,
         }
     }
 
+    fn take_task_marker(&mut self) -> Option<ListKind> {
+        let checked = match self.iter.peek() {
+            Some((Event::TaskListMarker(checked), _)) => *checked,
+            _ => return None,
+        };
+        self.iter.next();
+        Some(task_list_kind(checked))
+    }
+
     // Shared inline content parser
     //
-    // InlineContent ::= (Text | Code | Break | Emphasis | Strong | Strike
-    //                    | Link | Image)*
+    // InlineContent ::= Inline*
+    // Inline        ::= Text | Code | InlineHtml | Break | Emphasis | Strong
+    //                   | Strike | Link | Image
+    // Break         ::= SoftBreak | HardBreak
+    // Emphasis      ::= InlineContent
+    // Strong        ::= InlineContent
+    // Strike        ::= InlineContent
+    // Link          ::= InlineContent
+    // Image         ::= InlineContent
 
     /// Consumes events until `stop`, producing styled inline spans.
     fn parse_inline_content(&mut self, stop: TagEnd) -> Vec<InlineSpan> {
@@ -540,6 +550,14 @@ impl<'a> ParseState<'a> {
     }
 }
 
+fn task_list_kind(checked: bool) -> ListKind {
+    ListKind::Task(if checked {
+        TaskStatus::Checked
+    } else {
+        TaskStatus::Unchecked
+    })
+}
+
 /// Builds a plain inline span carrying the active style stack.
 fn text_span(
     source: &str,
@@ -630,6 +648,13 @@ mod tests {
         match &node.kind {
             NodeKind::Code(id) => doc.codes.by_id(*id).unwrap(),
             _ => panic!("Expected Code"),
+        }
+    }
+
+    fn list_item_text(item: &ListItem, source: &str) -> String {
+        match item.children.first().map(|node| &node.kind) {
+            Some(NodeKind::Paragraph(spans)) => inline_text(spans, source),
+            _ => String::new(),
         }
     }
 
@@ -754,7 +779,7 @@ mod tests {
                 NodeKind::List(items) => {
                     for &(idx, expected_text, ref expected_kind) in &expected_checks {
                         assert_eq!(
-                            inline_text(&items[idx].text, input),
+                            list_item_text(&items[idx], input),
                             expected_text,
                             "item {idx}, input: {input:?}"
                         );
@@ -767,6 +792,28 @@ mod tests {
                 _ => panic!("Expected List, input: {input:?}"),
             }
         }
+    }
+
+    #[test]
+    fn test_list_item_stores_all_blocks_as_children() {
+        let input = "1. First item\n\n   Nested paragraph.\n\n   ```sh\n   echo nested\n   ```";
+        let doc = Parser::new().parse(input);
+        let NodeKind::List(items) = &doc.nodes[0].kind else {
+            panic!("expected list");
+        };
+        let item = &items[0];
+        assert_eq!(&input[item.range.clone()], input);
+
+        assert_eq!(item.children.len(), 3);
+        let NodeKind::Paragraph(first) = &item.children[0].kind else {
+            panic!("expected first paragraph");
+        };
+        assert_eq!(inline_text(first, input), "First item");
+        let NodeKind::Paragraph(paragraph) = &item.children[1].kind else {
+            panic!("expected nested paragraph before code");
+        };
+        assert_eq!(inline_text(paragraph, input), "Nested paragraph.");
+        assert!(matches!(item.children[2].kind, NodeKind::Code(_)));
     }
 
     #[test]
@@ -827,7 +874,7 @@ mod tests {
         assert_eq!(doc.headings.len(), 2);
         assert_eq!(doc.headings[0].level, 1);
         assert_eq!(doc.headings[0].text, "Title");
-        assert_eq!(doc.headings[0].start_line, 1);
+        assert_eq!(doc.headings[0].source_range, 0..8);
         assert_eq!(doc.headings[1].level, 2);
         assert_eq!(doc.headings[1].text, "Run `make`");
         assert_eq!(doc.nodes_state, crate::NodesState::Full);
@@ -902,9 +949,12 @@ mod tests {
                 assert_eq!(children.len(), 1);
                 match &children[0].kind {
                     NodeKind::Paragraph(spans) => {
-                        assert!(inline_text(spans, text).contains("blockquote"))
+                        assert_eq!(
+                            inline_text(spans, text),
+                            "This is a blockquote\nwith multiple lines"
+                        );
                     }
-                    _ => panic!("Expected Paragraph in BlockQuote"),
+                    _ => panic!("Expected Paragraph"),
                 }
             }
             _ => panic!("Expected BlockQuote"),
@@ -928,10 +978,10 @@ mod tests {
             _ => panic!("expected list"),
         };
         assert_eq!(items.len(), 2);
-        assert_eq!(inline_text(&items[0].text, text), "item 1");
-        assert_eq!(inline_text(&items[1].text, text), "item 2");
-        assert_eq!(items[0].children.len(), 1);
-        assert!(matches!(&items[0].children[0].kind, NodeKind::Code(code_id)
+        assert_eq!(list_item_text(&items[0], text), "item 1");
+        assert_eq!(list_item_text(&items[1], text), "item 2");
+        assert_eq!(items[0].children.len(), 2);
+        assert!(matches!(&items[0].children[1].kind, NodeKind::Code(code_id)
             if doc.codes.iter().any(|c| c.id == *code_id && c.content.trim() == "echo hi")));
     }
 
@@ -1134,13 +1184,12 @@ mod tests {
                 other => panic!("Expected List for {markdown:?}, got {other:?}"),
             };
 
-            assert_eq!(inline_text(&items[0].text, &input), expected_text);
-            assert_eq!(items[0].text.len(), 1, "input: {markdown:?}");
-
-            assert_eq!(
-                items[0].text[0].style, expected_styles,
-                "input: {markdown:?}"
-            );
+            let NodeKind::Paragraph(spans) = &items[0].children[0].kind else {
+                panic!("expected list-item paragraph");
+            };
+            assert_eq!(inline_text(spans, &input), expected_text);
+            assert_eq!(spans.len(), 1, "input: {markdown:?}");
+            assert_eq!(spans[0].style, expected_styles, "input: {markdown:?}");
         }
     }
     #[test]

--- a/crates/upmd-parser/tests/nested_checkbox_test.rs
+++ b/crates/upmd-parser/tests/nested_checkbox_test.rs
@@ -1,4 +1,11 @@
-use upmd_parser::nodes::inline_text;
+use upmd_parser::nodes::{inline_text, ListItem, NodeKind};
+
+fn item_text(item: &ListItem, source: &str) -> String {
+    match item.children.first().map(|node| &node.kind) {
+        Some(NodeKind::Paragraph(spans)) => inline_text(spans, source),
+        _ => String::new(),
+    }
+}
 
 #[test]
 fn test_nested_checkbox_parsing() {
@@ -23,7 +30,7 @@ fn test_nested_checkbox_parsing() {
                     i,
                     item.depth,
                     item.kind,
-                    inline_text(&item.text, &doc.source)
+                    item_text(item, &doc.source)
                 );
             }
 
@@ -38,13 +45,13 @@ fn test_nested_checkbox_parsing() {
                 non_task.len(),
                 non_task
                     .iter()
-                    .map(|i| inline_text(&i.text, &doc.source))
+                    .map(|item| item_text(item, &doc.source))
                     .collect::<Vec<_>>()
             );
 
             // Parent items must NOT contain nested list source in their text
             for item in items.iter().filter(|i| i.depth == 1) {
-                let text = inline_text(&item.text, &doc.source);
+                let text = item_text(item, &doc.source);
                 assert!(
                     !text.contains("- [x]"),
                     "depth-1 item '{}' should not contain nested checkbox source text",

--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -27,6 +27,9 @@ use upmd_parser::Codes;
 use crate::apps::task::Task;
 use crate::apps::tui::wrap::slice_line;
 
+/// CommonMark allows up to three leading spaces before a blockquote marker.
+const MAX_BLOCKQUOTE_MARKER_INDENT: usize = 3;
+
 /// How the preview renders the parsed markdown AST.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RenderMode {
@@ -344,6 +347,9 @@ pub struct LogicalLine {
     /// Number of leading rendered characters repeated on wrapped rows, such as
     /// `▎ ` in Visual mode or `> ` in Markup mode.
     wrap_prefix_width: usize,
+    /// Styled prefix painted on continuation rows when it differs from the
+    /// leading rendered text, such as spaces replacing a list marker.
+    wrap_prefixes: Option<Vec<Span<'static>>>,
     /// Optional foreground color override for the gutter indicator (used by
     /// output lines to reflect task status).
     pub gutter_fg: Option<Color>,
@@ -353,11 +359,9 @@ pub struct LogicalLine {
 
 impl LogicalLine {
     /// Creates an empty newline.
-    pub fn newline(code_id: Option<CodeId>, is_block_start: bool) -> Self {
+    pub fn newline() -> Self {
         Self {
             source: LogicalLineSource::Newline,
-            code_id,
-            is_block_start,
             ..Self::default()
         }
     }
@@ -376,12 +380,14 @@ impl LogicalLine {
         spans: Vec<InlineSpan>,
         source: &str,
         prefix: Span<'static>,
+        wrap_prefix: Span<'static>,
         is_block_start: bool,
     ) -> Self {
         Self {
             source: LogicalLineSource::ListItem(LazyText::from_spans(spans, source)),
             is_block_start,
             prefixes: vec![prefix],
+            wrap_prefixes: Some(vec![wrap_prefix]),
             ..Self::default()
         }
     }
@@ -540,6 +546,10 @@ impl LogicalLine {
         self.wrap_prefix_width
     }
 
+    pub fn wrap_prefixes(&self) -> Option<&[Span<'static>]> {
+        self.wrap_prefixes.as_deref()
+    }
+
     pub fn reserved_prefix_width(&self) -> usize {
         self.prefix_width().max(self.wrap_prefix_width)
     }
@@ -565,6 +575,11 @@ impl LogicalLine {
     #[inline]
     pub fn is_output(&self) -> bool {
         matches!(self.source, LogicalLineSource::Output(_))
+    }
+
+    #[inline]
+    pub fn is_newline(&self) -> bool {
+        matches!(self.source, LogicalLineSource::Newline)
     }
 
     #[inline]
@@ -1096,6 +1111,8 @@ struct RenderState {
     snap: SnapContext,
     /// Current blockquote nesting depth. Each level adds a display-only gutter.
     quote_depth: usize,
+    /// Ordered display prefixes contributed by the active render mode.
+    prefixes: Vec<Span<'static>>,
     /// Extra display width before code content, keyed by code block.
     code_prefix_overhead: HashMap<CodeId, usize>,
     /// Traversal index allocated to the next AST node.
@@ -1114,6 +1131,13 @@ impl RenderState {
 
     fn end_node(&mut self, parent: usize) {
         self.node_idx = parent;
+    }
+
+    fn prefix_width(&self) -> usize {
+        self.prefixes
+            .iter()
+            .map(|prefix| prefix.content.chars().count())
+            .sum()
     }
 }
 
@@ -1189,7 +1213,7 @@ impl<'a> MarkdownRenderer<'a> {
             }
             None => false,
         };
-        let gutter_width = Self::quote_prefix_width(state.quote_depth);
+        let gutter_width = state.prefix_width();
         if gutter_width > 0 {
             state.code_prefix_overhead.insert(code.id, gutter_width);
         }
@@ -1208,36 +1232,19 @@ impl<'a> MarkdownRenderer<'a> {
         self.push_line(lines, info, state);
         self.render_code_body(code, lines, state, gutter_fg, is_running);
         self.render_code_output(code, lines, state, gutter_fg, is_running);
-        self.push_line(lines, LogicalLine::newline(Some(code.id), false), state);
-    }
-
-    fn quote_prefix_span(&self) -> Span<'static> {
-        // Quote prefixes sit outside code backgrounds. Pinning the background
-        // avoids inheriting the highlighted/code block background that is added
-        // later during LogicalLine::render.
-        let content = match self.mode {
-            RenderMode::Visual => "▎ ",
-            RenderMode::Markup => "> ",
-        };
-        Span::styled(
-            content,
-            Style::default()
-                .fg(self.theme.muted)
-                .bg(self.theme.background),
-        )
-    }
-
-    fn quote_prefix_width(depth: usize) -> usize {
-        depth * 2
     }
 
     fn push_line(&self, lines: &mut Vec<LogicalLine>, mut line: LogicalLine, state: &RenderState) {
-        // Quote prefixes are outer chrome. Insert them before existing list/task
-        // prefixes so rendering preserves Markdown nesting order.
-        line.wrap_prefix_width = Self::quote_prefix_width(state.quote_depth);
-        for _ in 0..state.quote_depth {
-            line.prefixes.insert(0, self.quote_prefix_span());
+        let mut wrap_prefixes = state.prefixes.clone();
+        if let Some(line_prefixes) = line.wrap_prefixes.take() {
+            wrap_prefixes.extend(line_prefixes);
         }
+        line.wrap_prefix_width = wrap_prefixes
+            .iter()
+            .map(|prefix| prefix.content.chars().count())
+            .sum();
+        line.wrap_prefixes = (!wrap_prefixes.is_empty()).then_some(wrap_prefixes);
+        line.prefixes.splice(0..0, state.prefixes.iter().cloned());
         self.push_unquoted_line(lines, line, state);
     }
 
@@ -1615,8 +1622,7 @@ fn inline_style(theme: &Theme, style: &InlineStyle) -> Style {
 
 /// Returns the byte width of the leading `> ` quote markers in source text.
 fn source_quote_width(text: &str) -> usize {
-    // CommonMark permits up to three spaces before a blockquote marker.
-    const MAX_MARKER_INDENT: usize = 3;
+    // Leading indentation is bounded by the CommonMark blockquote rule.
     let bytes = text.as_bytes();
     let mut pos = 0;
     let mut end = 0;
@@ -1624,8 +1630,8 @@ fn source_quote_width(text: &str) -> usize {
     loop {
         let spaces = bytes[pos..]
             .iter()
-            .take(MAX_MARKER_INDENT)
-            .take_while(|&&b| b == b' ')
+            .take(MAX_BLOCKQUOTE_MARKER_INDENT)
+            .take_while(|&&byte| byte == b' ')
             .count();
         if bytes.get(pos + spaces) != Some(&b'>') {
             break;
@@ -1706,7 +1712,11 @@ mod tests {
                 } else {
                     text
                 };
-                format!("{:2}: [{}] {}", i, source_label(l), preview)
+                if preview.is_empty() {
+                    format!("{:2}: [{}]", i, source_label(l))
+                } else {
+                    format!("{:2}: [{}] {}", i, source_label(l), preview)
+                }
             })
             .collect::<Vec<_>>()
             .join("\n")

--- a/src/apps/tui/markdown/markup.rs
+++ b/src/apps/tui/markdown/markup.rs
@@ -1,5 +1,6 @@
 //! Source-preserving Markdown rendering for the preview's Markup mode.
 
+use ratatui::{style::Style, text::Span};
 use std::ops::Range;
 
 use upmd_parser::nodes::{Node, NodeKind};
@@ -20,6 +21,15 @@ impl MarkdownRenderer<'_> {
             cursor = cursor.max(node.range.end);
         }
         self.render_markup_gap(cursor..self.source.len(), lines, state);
+    }
+
+    fn markup_code_prefix(&self, content: String) -> Span<'static> {
+        Span::styled(
+            content,
+            Style::default()
+                .fg(self.theme.muted)
+                .bg(self.theme.background),
+        )
     }
 
     fn render_markup_node(
@@ -65,11 +75,19 @@ impl MarkdownRenderer<'_> {
     ) {
         let mut cursor = range.start;
         for (code, quote_depth) in codes {
-            let raw_end = self.quote_prefix_start(cursor, code.range.start, *quote_depth);
+            let raw_end = self.code_prefix_start(cursor, code.range.start, *quote_depth);
             self.render_markup_source(cursor..raw_end, lines, state);
 
             let parent_depth = std::mem::replace(&mut state.quote_depth, *quote_depth);
+            let prefix = self.source[raw_end..code.range.start].to_owned();
+            let prefixes = if prefix.is_empty() {
+                Vec::new()
+            } else {
+                vec![self.markup_code_prefix(prefix)]
+            };
+            let parent_prefixes = std::mem::replace(&mut state.prefixes, prefixes);
             self.render_markup_node(code, lines, state);
+            state.prefixes = parent_prefixes;
             state.quote_depth = parent_depth;
             cursor = self.after_line_ending(cursor.max(code.range.end));
         }
@@ -90,10 +108,7 @@ impl MarkdownRenderer<'_> {
         }
     }
 
-    fn quote_prefix_start(&self, start: usize, end: usize, quote_depth: usize) -> usize {
-        if quote_depth == 0 {
-            return end;
-        }
+    fn code_prefix_start(&self, start: usize, end: usize, quote_depth: usize) -> usize {
         let line_start = self.source[start..end]
             .rfind('\n')
             .map_or(start, |offset| start + offset + 1);
@@ -153,7 +168,7 @@ impl MarkdownRenderer<'_> {
             newline_count.saturating_sub(1)
         };
         for _ in 0..blank_lines {
-            self.push_unquoted_line(lines, LogicalLine::newline(None, false), state);
+            self.push_unquoted_line(lines, LogicalLine::newline(), state);
         }
     }
 }

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__blockquote.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__blockquote.snap
@@ -1,14 +1,12 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1537
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Text] quoted paragraph
- 1: [Newline] 
+ 1: [Newline]
  2: [CodeInfo] 1 Bash
  3: [CodeBody] echo hi
- 4: [Newline] 
+ 4: [Newline]
  5: [ListItem] quoted item
  6: [ListItem] nested quote
  7: [ListItem] deeper
- 8: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__bullet_list.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__bullet_list.snap
@@ -1,9 +1,8 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1439
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 581
 expression: logical_line_summary(&lines)
 ---
  0: [ListItem] item one
  1: [ListItem] item two
  2: [ListItem] item three
- 3: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__code_with_attr.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__code_with_attr.snap
@@ -1,8 +1,7 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1433
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 575
 expression: logical_line_summary(&lines)
 ---
  0: [CodeInfo] 1 Python
  1: [CodeBody] print('hi')
- 2: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__fenced_code.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__fenced_code.snap
@@ -1,8 +1,7 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1427
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 569
 expression: logical_line_summary(&lines)
 ---
  0: [CodeInfo] 1 Bash
  1: [CodeBody] echo hello
- 2: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__headings.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__headings.snap
@@ -1,9 +1,9 @@
 ---
-source: src/apps/tui/markdown.rs
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Heading(1)] # Hello
- 1: [ThematicBreak] 
+ 1: [ThematicBreak]
  2: [Heading(2)] ## World
- 3: [ThematicBreak] 
+ 3: [ThematicBreak]
  4: [Heading(3)] ### Rust

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__inline_styles.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__inline_styles.snap
@@ -1,11 +1,10 @@
 ---
-source: src/apps/tui/markdown.rs
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Text] bold italic strike `code` link alt text
- 1: [Newline] 
+ 1: [Newline]
  2: [Heading(2)] ## Heading with bold
- 3: [ThematicBreak] 
+ 3: [ThematicBreak]
  4: [ListItem] bold item
  5: [ListItem] italic item
- 6: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__mixed_runbook.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__mixed_runbook.snap
@@ -1,18 +1,17 @@
 ---
-source: src/apps/tui/markdown.rs
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Heading(1)] # Setup
- 1: [ThematicBreak] 
+ 1: [ThematicBreak]
  2: [Text] Install dependencies.
- 3: [Newline] 
+ 3: [Newline]
  4: [CodeInfo] 1 Bash
  5: [CodeBody] npm install
- 6: [Newline] 
+ 6: [Newline]
  7: [Heading(2)] ## Test
- 8: [ThematicBreak] 
+ 8: [ThematicBreak]
  9: [Text] Run the test suite.
-10: [Newline] 
+10: [Newline]
 11: [CodeInfo] 2 Python
 12: [CodeBody] pytest tests/
-13: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__ordered_list.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__ordered_list.snap
@@ -1,9 +1,8 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1445
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 587
 expression: logical_line_summary(&lines)
 ---
  0: [ListItem] first
  1: [ListItem] second
  2: [ListItem] third
- 3: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__paragraph.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__paragraph.snap
@@ -1,9 +1,7 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1421
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Text] This is a paragraph.
- 1: [Newline] 
+ 1: [Newline]
  2: [Text] With a blank line.
- 3: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__table.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__table.snap
@@ -1,6 +1,6 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1464
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 767
 expression: logical_line_summary(&lines)
 ---
  0: [Table] ┌───────┬─────┐
@@ -9,4 +9,3 @@ expression: logical_line_summary(&lines)
  3: [Table] │ Alice │ 30  │
  4: [Table] │ Bob   │ 25  │
  5: [Table] └───────┴─────┘
- 6: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__task_list.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__task_list.snap
@@ -1,9 +1,8 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1451
+source: src/apps/tui/markdown/visual.rs
+assertion_line: 593
 expression: logical_line_summary(&lines)
 ---
  0: [ListItem] unchecked
  1: [ListItem] checked
  2: [ListItem] [-] in progress
- 3: [Newline]

--- a/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__thematic_break.snap
+++ b/src/apps/tui/markdown/snapshots/upmd__apps__tui__markdown__visual__tests__thematic_break.snap
@@ -1,11 +1,9 @@
 ---
-source: src/apps/tui/markdown.rs
-assertion_line: 1457
+source: src/apps/tui/markdown/visual.rs
 expression: logical_line_summary(&lines)
 ---
  0: [Text] above
- 1: [Newline] 
- 2: [ThematicBreak] 
- 3: [Newline] 
+ 1: [Newline]
+ 2: [ThematicBreak]
+ 3: [Newline]
  4: [Text] below
- 5: [Newline]

--- a/src/apps/tui/markdown/visual.rs
+++ b/src/apps/tui/markdown/visual.rs
@@ -3,13 +3,13 @@
 use std::rc::Rc;
 
 use ratatui::{style::Style, text::Span};
-use upmd_parser::nodes::{InlineSpan, ListKind, TaskStatus};
+use upmd_parser::nodes::{InlineSpan, ListItem, ListKind, Node, NodeKind, TaskStatus};
 
 use crate::apps::config::PREVIEW_FRAME_OVERHEAD;
 
 use super::{
     owned_table, render_table, split_span_lines, FrontmatterBlock, LogicalLine, LogicalLineSource,
-    MarkdownHtml, MarkdownRenderer, MarkdownTable, RenderState,
+    MarkdownHtml, MarkdownRenderer, MarkdownTable, RenderState, MAX_BLOCKQUOTE_MARKER_INDENT,
 };
 
 impl MarkdownRenderer<'_> {
@@ -19,9 +19,47 @@ impl MarkdownRenderer<'_> {
         lines: &mut Vec<LogicalLine>,
         state: &mut RenderState,
     ) {
-        for node in nodes {
-            self.render_node(node, lines, state);
+        self.render_nodes(nodes, lines, state, Self::render_node);
+        if lines.last().is_some_and(LogicalLine::is_newline) {
+            lines.pop();
         }
+    }
+
+    /// Whether this heading renders its own visual separator.
+    fn has_heading_rule(node: &Node) -> bool {
+        matches!(
+            &node.kind,
+            NodeKind::Heading { level, .. } if *level <= 2
+        )
+    }
+
+    /// Renders each node with one trailing separator in the current nesting
+    /// context, except after H1/H2. The outermost render removes the final one.
+    fn render_nodes(
+        &self,
+        nodes: &[Node],
+        lines: &mut Vec<LogicalLine>,
+        state: &mut RenderState,
+        mut render: impl FnMut(&Self, &Node, &mut Vec<LogicalLine>, &mut RenderState),
+    ) {
+        for node in nodes {
+            render(self, node, lines, state);
+            if lines.last().is_some_and(LogicalLine::is_newline) {
+                lines.pop();
+            }
+            if !Self::has_heading_rule(node) {
+                self.push_line(lines, LogicalLine::newline(), state);
+            }
+        }
+    }
+
+    fn visual_quote_prefix(&self) -> Span<'static> {
+        Span::styled(
+            "▎ ",
+            Style::default()
+                .fg(self.theme.muted)
+                .bg(self.theme.background),
+        )
     }
 
     pub(super) fn render_node(
@@ -43,7 +81,6 @@ impl MarkdownRenderer<'_> {
                         state,
                     );
                 }
-                self.push_line(lines, LogicalLine::newline(None, false), state);
             }
             NodeKind::Frontmatter { style, raw } => {
                 let block = Rc::new(FrontmatterBlock::new(
@@ -57,7 +94,6 @@ impl MarkdownRenderer<'_> {
                         state,
                     );
                 }
-                self.push_line(lines, LogicalLine::newline(None, false), state);
             }
             NodeKind::Text(t) => {
                 self.render_highlighted_lines(t, lines, true, state);
@@ -73,11 +109,9 @@ impl MarkdownRenderer<'_> {
                 // snap target for a following non-quoted code block, and an
                 // outer paragraph should not snap to quoted code.
                 let parent_snap = std::mem::take(&mut state.snap);
-                state.quote_depth += 1;
-                for child in children {
-                    self.render_node(child, lines, state);
-                }
-                state.quote_depth = state.quote_depth.saturating_sub(1);
+                state.prefixes.push(self.visual_quote_prefix());
+                self.render_nodes(children, lines, state, Self::render_node);
+                state.prefixes.pop();
                 state.snap = parent_snap;
             }
             NodeKind::Heading { text: t, level } => {
@@ -103,7 +137,7 @@ impl MarkdownRenderer<'_> {
                     LogicalLine::heading_lazy_spans(content, self.source, *level),
                     state,
                 );
-                if *level <= 2 {
+                if Self::has_heading_rule(node) {
                     self.push_line(lines, LogicalLine::heading_rule(), state);
                 }
                 state.snap.title_line = Some(line_idx);
@@ -114,7 +148,7 @@ impl MarkdownRenderer<'_> {
                 let table_width = self
                     .viewport_width
                     .saturating_sub(PREVIEW_FRAME_OVERHEAD)
-                    .saturating_sub(Self::quote_prefix_width(state.quote_depth))
+                    .saturating_sub(state.prefix_width())
                     .max(1);
                 let table = owned_table(table, self.source);
                 let rendered = render_table(&table, "", self.theme, table_width);
@@ -128,11 +162,9 @@ impl MarkdownRenderer<'_> {
                         state,
                     );
                 }
-                self.push_line(lines, LogicalLine::newline(None, false), state);
             }
             NodeKind::ThematicBreak => {
                 self.push_line(lines, LogicalLine::thematic_break(), state);
-                self.push_line(lines, LogicalLine::newline(None, false), state);
             }
             NodeKind::Image { alt, src } => {
                 let line = LogicalLine {
@@ -144,7 +176,6 @@ impl MarkdownRenderer<'_> {
                     ..LogicalLine::default()
                 };
                 self.push_line(lines, line, state);
-                self.push_line(lines, LogicalLine::newline(None, false), state);
             }
         }
         state.end_node(parent_identity);
@@ -169,7 +200,6 @@ impl MarkdownRenderer<'_> {
             first = false;
             emitted = true;
         }
-        self.push_line(lines, LogicalLine::newline(None, false), state);
         if emitted {
             Some(start_idx)
         } else {
@@ -177,57 +207,124 @@ impl MarkdownRenderer<'_> {
         }
     }
 
+    /// Returns source indentation for a nested block after stripping enclosing
+    /// blockquote prefixes.
+    fn nested_block_indent(&self, offset: usize) -> usize {
+        let line_start = self.source[..offset]
+            .rfind('\n')
+            .map_or(0, |index| index + 1);
+        let mut prefix = &self.source[line_start..offset];
+
+        loop {
+            let spaces = prefix
+                .bytes()
+                .take(MAX_BLOCKQUOTE_MARKER_INDENT)
+                .take_while(|byte| *byte == b' ')
+                .count();
+            let Some(rest) = prefix.get(spaces..) else {
+                break;
+            };
+            let Some(rest) = rest.strip_prefix('>') else {
+                break;
+            };
+            prefix = rest
+                .strip_prefix(' ')
+                .or_else(|| rest.strip_prefix('\t'))
+                .unwrap_or(rest);
+        }
+
+        prefix
+            .chars()
+            .fold(0, |width, ch| width + if ch == '\t' { 4 } else { 1 })
+    }
+
     fn render_list(
         &self,
-        items: &[upmd_parser::nodes::ListItem],
+        items: &[ListItem],
         lines: &mut Vec<LogicalLine>,
         state: &mut RenderState,
     ) {
-        for (i, item) in items.iter().enumerate() {
-            let indent = " ".repeat(item.depth.saturating_sub(1) * 4);
+        for (index, item) in items.iter().enumerate() {
+            self.render_list_item(item, index == 0, lines, state);
+        }
+    }
 
-            let (marker, color) = match &item.kind {
-                ListKind::Bullet => ("• ".to_string(), self.theme.foreground),
-                ListKind::Ordered(n) => (format!("{}. ", n), self.theme.foreground),
-                ListKind::Task(status) => match status {
-                    TaskStatus::Checked => ("󰱒  ".to_string(), self.theme.success),
-                    TaskStatus::InProgress => ("󰡖  ".to_string(), self.theme.muted),
-                    TaskStatus::Unchecked => ("󰄱  ".to_string(), self.theme.muted),
+    fn render_list_item(
+        &self,
+        item: &ListItem,
+        is_list_start: bool,
+        lines: &mut Vec<LogicalLine>,
+        state: &mut RenderState,
+    ) {
+        let indent = " ".repeat(item.depth.saturating_sub(1) * 4);
+        let (marker, color) = match &item.kind {
+            ListKind::Bullet => ("• ".to_string(), self.theme.foreground),
+            ListKind::Ordered(number) => (format!("{number}. "), self.theme.foreground),
+            ListKind::Task(TaskStatus::Checked) => ("󰱒  ".to_string(), self.theme.success),
+            ListKind::Task(TaskStatus::InProgress) => ("󰡖  ".to_string(), self.theme.muted),
+            ListKind::Task(TaskStatus::Unchecked) => ("󰄱  ".to_string(), self.theme.muted),
+        };
+        let continuation = format!("{}{}", indent, " ".repeat(marker.chars().count()));
+
+        let (paragraph, children) = match item.children.split_first() {
+            Some((
+                Node {
+                    kind: NodeKind::Paragraph(spans),
+                    ..
                 },
+                children,
+            )) => (Some(spans.as_slice()), children),
+            _ => (None, item.children.as_slice()),
+        };
+        let paragraph_lines = paragraph.map_or_else(
+            || vec![Vec::new()],
+            |spans| split_span_lines(spans, self.source),
+        );
+
+        for (line_index, line) in paragraph_lines.into_iter().enumerate() {
+            let prefix = if line_index == 0 {
+                Span::styled(format!("{indent}{marker}"), Style::default().fg(color))
+            } else {
+                Span::raw(continuation.clone())
             };
-
-            let continuation = format!("{}{}", indent, " ".repeat(marker.chars().count()));
-
-            for (line_idx, line) in split_span_lines(&item.text, self.source)
-                .into_iter()
-                .enumerate()
-            {
-                let prefix = if line_idx == 0 {
-                    Span::styled(format!("{}{}", indent, marker), Style::default().fg(color))
-                } else {
-                    Span::raw(continuation.clone())
-                };
-                self.push_line(
-                    lines,
-                    LogicalLine::list_item_spans(
-                        line,
-                        self.source,
-                        prefix,
-                        i == 0 && line_idx == 0,
-                    ),
-                    state,
-                );
-            }
-            // Render nested children (code blocks, sub-lists, etc.) in the same
-            // quote scope so blockquote chrome applies consistently.
-            for child in &item.children {
-                self.render_node(child, lines, state);
-            }
+            self.push_line(
+                lines,
+                LogicalLine::list_item_spans(
+                    line,
+                    self.source,
+                    prefix,
+                    Span::raw(continuation.clone()),
+                    is_list_start && line_index == 0,
+                ),
+                state,
+            );
         }
-        // Skip trailing newline for nested lists to avoid blank lines between siblings.
-        if items.first().is_some_and(|i| i.depth == 1) {
-            self.push_line(lines, LogicalLine::newline(None, false), state);
+
+        self.render_nodes(children, lines, state, Self::render_list_child);
+    }
+
+    fn render_list_child(
+        &self,
+        child: &Node,
+        lines: &mut Vec<LogicalLine>,
+        state: &mut RenderState,
+    ) {
+        let indent = if matches!(child.kind, NodeKind::List(_)) {
+            0
+        } else {
+            self.nested_block_indent(child.range.start)
+        };
+        if indent == 0 {
+            self.render_node(child, lines, state);
+            return;
         }
+
+        state.prefixes.push(Span::styled(
+            " ".repeat(indent),
+            Style::default().bg(self.theme.background),
+        ));
+        self.render_node(child, lines, state);
+        state.prefixes.pop();
     }
 }
 
@@ -299,7 +396,11 @@ mod tests {
                 } else {
                     text
                 };
-                format!("{:2}: [{}] {}", i, source_label(l), preview)
+                if preview.is_empty() {
+                    format!("{:2}: [{}]", i, source_label(l))
+                } else {
+                    format!("{:2}: [{}] {}", i, source_label(l), preview)
+                }
             })
             .collect::<Vec<_>>()
             .join("\n")
@@ -409,6 +510,36 @@ mod tests {
 
         assert_eq!(list_item.prefix_width(), 4);
         assert_eq!(list_item.render(&ctx).to_string(), "▎ • quoted item");
+    }
+
+    #[test]
+    fn test_nested_list_blocks_preserve_source_indentation() {
+        let theme = test_theme();
+        let ctx = test_ctx(&theme, 80);
+        let lines = render_nodes(
+            "1. First ordered item\n\n   Paragraph nested under the item.\n\n   ```python\n   print(\"list code\")\n   ```\n\n   > Quote nested under the item.\n   >\n   > - Quoted bullet\n\n2. Second ordered item\n\n   | A | B |\n   |---|---|\n   | x | y |\n\n- [ ] Parent task\n\n  > Task quote.\n\n  ```sh\n  echo task\n  ```",
+        );
+        let rendered = lines
+            .iter()
+            .map(|line| line.render(&ctx).to_string())
+            .collect::<Vec<_>>();
+
+        for expected in [
+            "   Paragraph nested under the item.",
+            "   ▎ 1",
+            "   ▎ print(\"list code\")",
+            "   ▎ Quote nested under the item.",
+            "   ▎ • Quoted bullet",
+            "   ┌",
+            "  ▎ Task quote.",
+            "  ▎ 2",
+            "  ▎ echo task",
+        ] {
+            assert!(
+                rendered.iter().any(|line| line.starts_with(expected)),
+                "missing {expected:?} in {rendered:#?}"
+            );
+        }
     }
 
     #[test]

--- a/src/apps/tui/preview/layout_lines.rs
+++ b/src/apps/tui/preview/layout_lines.rs
@@ -98,7 +98,10 @@ impl LayoutLine {
             return;
         }
         let width = logical_line.wrap_prefix_width();
-        let prefix = slice_line(rendered_line, 0..width).spans;
+        let prefix = logical_line
+            .wrap_prefixes()
+            .map(<[ratatui::text::Span<'static>]>::to_vec)
+            .unwrap_or_else(|| slice_line(rendered_line, 0..width).spans);
         line.spans.splice(0..0, prefix);
     }
 }

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -740,7 +740,7 @@ impl Preview {
         Some((col, pty_row as u16))
     }
 
-    /// Returns the gutter overhead in chars for a code block nested in a blockquote.
+    /// Returns display-prefix overhead before a code block's own gutter.
     pub fn code_prefix_overhead(&self, id: CodeId) -> usize {
         self.code_prefix_overhead.get(&id).copied().unwrap_or(0)
     }
@@ -760,21 +760,37 @@ impl Preview {
             spinner_char: ' ',
             viewport_width: self.layout_lines.last_width(),
         };
-        let rendered = line.render_plain(&self.logical_lines[line.logical_idx], &ctx);
-        let mut text: String = rendered
+        let logical_line = &self.logical_lines[line.logical_idx];
+        let mut rendered = line.render_plain(logical_line, &ctx);
+        let display_prefix_len = match (logical_line.has_code_gutter(), line.is_continuation()) {
+            (false, _) => 0,
+            (true, true) => CODE_GUTTER_WIDTH,
+            (true, false) => {
+                let gutter_idx = logical_line.prefixes.len();
+                if rendered
+                    .spans
+                    .get(gutter_idx)
+                    .is_some_and(|span| span.content == "▎")
+                {
+                    rendered.spans.remove(gutter_idx);
+                    if rendered
+                        .spans
+                        .get(gutter_idx)
+                        .is_some_and(|span| span.content == " ")
+                    {
+                        rendered.spans.remove(gutter_idx);
+                    }
+                    CODE_GUTTER_WIDTH
+                } else {
+                    0
+                }
+            }
+        };
+        let text = rendered
             .spans
             .iter()
             .map(|span| span.content.as_ref())
             .collect();
-        let has_code_gutter = self.logical_lines[line.logical_idx].has_code_gutter();
-        let display_prefix_len = match (has_code_gutter, text.strip_prefix("▎ ")) {
-            (true, Some(stripped)) => {
-                text = stripped.to_string();
-                CODE_GUTTER_WIDTH
-            }
-            (true, None) if line.is_continuation() => CODE_GUTTER_WIDTH,
-            _ => 0,
-        };
         Some(CopyLine {
             text,
             is_continuation: line.char_range.start > 0,
@@ -1573,6 +1589,32 @@ mod tests {
             code_rows.iter().all(|line| line.starts_with("> ▎ ")),
             "interactive code rows should retain the Markup quote marker, got: {rows}"
         );
+    }
+
+    #[test]
+    fn markup_nested_code_retains_list_indentation() {
+        for (markdown, prefix) in [
+            ("1. Parent\n\n   ```bash\n   echo ordered\n   ```", "   ▎ "),
+            ("- [ ] Parent\n\n  ```sh\n  echo task\n  ```", "  ▎ "),
+        ] {
+            let mut preview = preview_from_markdown(markdown);
+            preview.toggle_mode();
+            preview.rebuild_view(&HashMap::new());
+            preview.rebuild_layout_lines(80);
+            let rows = full_preview_text(&preview);
+            let code_rows = rows
+                .lines()
+                .filter(|line| {
+                    line.contains("Bash") || line.contains("Shell") || line.contains("echo")
+                })
+                .collect::<Vec<_>>();
+
+            assert_eq!(code_rows.len(), 2, "got: {rows}");
+            assert!(
+                code_rows.iter().all(|line| line.starts_with(prefix)),
+                "interactive code rows should retain {prefix:?}, got: {rows}"
+            );
+        }
     }
 
     #[test]

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_blockquote.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_blockquote.snap
@@ -1,9 +1,9 @@
 ---
 source: src/apps/tui/preview/mod.rs
+assertion_line: 1566
 expression: full_preview_text(&preview)
 ---
 ▎ quoted paragraph
 ▎
 ▎ ▎ 1                                              Bash
 ▎ ▎ echo hi
-▎

--- a/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_mixed_runbook.snap
+++ b/src/apps/tui/preview/snapshots/upmd__apps__tui__preview__tests__full_mixed_runbook.snap
@@ -10,6 +10,6 @@ Install deps.
 ▎ npm install
 
 ▎ note
-▎
+
 • a
 • b

--- a/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_bottom.snap
+++ b/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_bottom.snap
@@ -1,6 +1,6 @@
 ---
 source: src/apps/tui/markdown.rs
-assertion_line: 1704
+assertion_line: 1856
 expression: result
 ---
  0: [CodeInfo] 1 Bash
@@ -14,5 +14,4 @@ expression: result
  8: [Output]                       This is output lin
  9: [Output] e number 48
 10: [Output]            This is output line number 49
-11: [Output] 
-12: [Newline]
+11: [Output]

--- a/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_clamp.snap
+++ b/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_clamp.snap
@@ -1,6 +1,6 @@
 ---
 source: src/apps/tui/markdown.rs
-assertion_line: 1730
+assertion_line: 1882
 expression: result
 ---
  0: [CodeInfo] 1 Bash
@@ -15,4 +15,3 @@ expression: result
  9: [Output] output line number 4
 10: [Output]                     This is output line 
 11: [Output] number 5
-12: [Newline]

--- a/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_first_line.snap
+++ b/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_first_line.snap
@@ -1,6 +1,6 @@
 ---
 source: src/apps/tui/markdown.rs
-assertion_line: 1691
+assertion_line: 1843
 expression: result
 ---
  0: [CodeInfo] 1 Bash
@@ -15,4 +15,3 @@ expression: result
  9: [Output] output line number 4
 10: [Output]                     This is output line 
 11: [Output] number 5
-12: [Newline]

--- a/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_middle.snap
+++ b/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_middle.snap
@@ -1,6 +1,6 @@
 ---
 source: src/apps/tui/markdown.rs
-assertion_line: 1717
+assertion_line: 1869
 expression: result
 ---
  0: [CodeInfo] 1 Bash
@@ -15,4 +15,3 @@ expression: result
  9: [Output]                 This is output line numb
 10: [Output] er 34
 11: [Output]      This is output line number 35
-12: [Newline]

--- a/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_short.snap
+++ b/src/apps/tui/snapshots/upmd__apps__tui__markdown__tests__inline_scroll_short.snap
@@ -1,6 +1,6 @@
 ---
 source: src/apps/tui/markdown.rs
-assertion_line: 1746
+assertion_line: 1898
 expression: result
 ---
  0: [CodeInfo] 1 Bash
@@ -11,5 +11,4 @@ expression: result
  5: [Output]                                     shor
  6: [Output] t line 3
  7: [Output]         short line 4
- 8: [Output]                      
- 9: [Newline]
+ 8: [Output]


### PR DESCRIPTION
## Summary

Fixes nested blocks (code, blockquotes, tables) inside list items losing their source indentation in `Visual` and `Markup` render modes.

 - Parses every block kind as a list-item child instead of stopping at list boundaries, so nested content is retained in the AST
 - Computes nested-block indentation from source offsets so code/quote/table content aligns with the parent list marker
 - Refactor the parser

<img width="451" height="467" alt="image" src="https://github.com/user-attachments/assets/4c395da4-f9b6-4cad-8f94-4ae1cb58e8cb" />
