### PR TITLE
refactor(tui): extract gutter glyph to config constant

### DIFF
--- a/src/apps/config.rs
+++ b/src/apps/config.rs
@@ -62,6 +62,9 @@ pub const PREVIEW_FRAME_OVERHEAD: usize = 4;
 /// Width of the gutter prepended to code-block lines (`"▎ "`).
 pub const CODE_GUTTER_WIDTH: usize = 2;
 
+/// Vertical-bar glyph used for code-block and blockquote gutters.
+pub const GUTTER_GLYPH: &str = "▎";
+
 /// Total horizontal overhead for code-block content (frame + gutter).
 pub const PREVIEW_CODE_WRAP_OVERHEAD: usize = PREVIEW_FRAME_OVERHEAD + CODE_GUTTER_WIDTH;
 

--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
 
-use crate::apps::config::PREVIEW_FRAME_OVERHEAD;
+use crate::apps::config::{GUTTER_GLYPH, PREVIEW_FRAME_OVERHEAD};
 use crate::apps::theme::Theme;
 use crate::runner::CodeId;
 use upmd_parser::nodes::{
@@ -886,7 +886,7 @@ pub fn apply_gutter(
         prefer_status_gutter,
         is_running,
     );
-    let gutter = Span::styled("\u{258E}", gs);
+    let gutter = Span::styled(GUTTER_GLYPH, gs);
     let has_content = !line.spans.is_empty();
     line.spans.insert(0, gutter);
     if has_content {

--- a/src/apps/tui/markdown/visual.rs
+++ b/src/apps/tui/markdown/visual.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 use ratatui::{style::Style, text::Span};
 use upmd_parser::nodes::{InlineSpan, ListItem, ListKind, Node, NodeKind, TaskStatus};
 
-use crate::apps::config::PREVIEW_FRAME_OVERHEAD;
+use crate::apps::config::{GUTTER_GLYPH, PREVIEW_FRAME_OVERHEAD};
 
 use super::{
     owned_table, render_table, split_span_lines, FrontmatterBlock, LogicalLine, LogicalLineSource,
@@ -55,7 +55,7 @@ impl MarkdownRenderer<'_> {
 
     fn visual_quote_prefix(&self) -> Span<'static> {
         Span::styled(
-            "▎ ",
+            format!("{GUTTER_GLYPH} "),
             Style::default()
                 .fg(self.theme.muted)
                 .bg(self.theme.background),

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -29,9 +29,9 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use crate::apps::config::{
-    BORDER_HEIGHT, CODE_GUTTER_WIDTH, INLINE_MAX_LINES_DEFAULT, INLINE_MAX_LINES_FRACTION,
-    INLINE_MAX_LINES_MIN, OVERDRAW_FRACTION, PREVIEW_CONTENT_TOP_OFFSET, PREVIEW_CONTENT_X_OFFSET,
-    PREVIEW_FRAME_OVERHEAD,
+    BORDER_HEIGHT, CODE_GUTTER_WIDTH, GUTTER_GLYPH, INLINE_MAX_LINES_DEFAULT,
+    INLINE_MAX_LINES_FRACTION, INLINE_MAX_LINES_MIN, OVERDRAW_FRACTION, PREVIEW_CONTENT_TOP_OFFSET,
+    PREVIEW_CONTENT_X_OFFSET, PREVIEW_FRAME_OVERHEAD,
 };
 use crate::apps::theme::Theme;
 use crate::runner::CodeId;
@@ -770,7 +770,7 @@ impl Preview {
                 if rendered
                     .spans
                     .get(gutter_idx)
-                    .is_some_and(|span| span.content == "▎")
+                    .is_some_and(|span| span.content == GUTTER_GLYPH)
                 {
                     rendered.spans.remove(gutter_idx);
                     if rendered


### PR DESCRIPTION
## Summary
Extract gutter glyph `▎` to config constant