### PR TITLE
perf(tui): batch and reuse syntax highlights

### DIFF
--- a/src/apps/tui/markdown.rs
+++ b/src/apps/tui/markdown.rs
@@ -12,6 +12,7 @@ use ratatui::style::{Color, Modifier, Style, Stylize};
 use ratatui::text::{Line, Span, Text};
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::ops::Range;
 use std::rc::Rc;
 use unicode_width::UnicodeWidthChar;
 
@@ -85,6 +86,10 @@ impl LazyText {
         text.spans = spans;
         text
     }
+
+    pub(crate) fn same_content(&self, other: &Self) -> bool {
+        self.text == other.text && self.language == other.language && self.spans == other.spans
+    }
 }
 
 impl Default for LazyText {
@@ -95,56 +100,6 @@ impl Default for LazyText {
             spans: Vec::new(),
             cached: std::cell::RefCell::new(None),
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct MarkdownHtml {
-    source: String,
-    lines: Vec<String>,
-    cached: RefCell<Option<Text<'static>>>,
-}
-
-impl MarkdownHtml {
-    fn new(source: String) -> Self {
-        let lines = source.lines().map(str::to_owned).collect();
-        Self {
-            source,
-            lines,
-            cached: RefCell::new(None),
-        }
-    }
-
-    pub(crate) fn source(&self) -> &str {
-        &self.source
-    }
-
-    fn len(&self) -> usize {
-        self.lines.len()
-    }
-
-    fn raw_line(&self, row_idx: usize) -> &str {
-        self.lines.get(row_idx).map_or("", String::as_str)
-    }
-
-    fn line(&self, row_idx: usize, theme: &Theme) -> Line<'static> {
-        let mut cached = self.cached.borrow_mut();
-        if cached.is_none() {
-            let mut rendered = theme.highlight(&self.source, "html");
-            for line in &mut rendered.lines {
-                *line = expand_tabs_in_line(std::mem::take(line));
-            }
-            *cached = Some(rendered);
-        }
-        cached
-            .as_ref()
-            .and_then(|text| text.lines.get(row_idx))
-            .cloned()
-            .unwrap_or_else(|| expand_tabs_in_line(Line::raw(self.raw_line(row_idx).to_owned())))
-    }
-
-    fn clear_cache(&self) {
-        *self.cached.borrow_mut() = None;
     }
 }
 
@@ -263,6 +218,8 @@ impl MarkdownTable {
 #[derive(Debug, Clone, Default)]
 pub enum LogicalLineSource {
     Text(LazyText),
+    /// Raw Markdown source prepared in viewport-sized syntax-highlighted batches.
+    Markup(LazyText),
     ListItem(LazyText),
     Heading {
         level: u8,
@@ -275,11 +232,8 @@ pub enum LogicalLineSource {
     },
     CodeBody(LazyText),
     Output(Text<'static>),
-    /// One row of a raw HTML block highlighted and cached as a complete block.
-    Html {
-        block: Rc<MarkdownHtml>,
-        row_idx: usize,
-    },
+    /// One row of a raw HTML block.
+    Html(LazyText),
     Frontmatter {
         block: Rc<FrontmatterBlock>,
         row_idx: usize,
@@ -306,6 +260,8 @@ impl LogicalLineSource {
     fn lazy_text_mut(&mut self) -> Option<&mut LazyText> {
         match self {
             LogicalLineSource::Text(text)
+            | LogicalLineSource::Markup(text)
+            | LogicalLineSource::Html(text)
             | LogicalLineSource::ListItem(text)
             | LogicalLineSource::CodeBody(text)
             | LogicalLineSource::Heading { text, .. } => Some(text),
@@ -316,6 +272,8 @@ impl LogicalLineSource {
     fn lazy_text(&self) -> Option<&LazyText> {
         match self {
             LogicalLineSource::Text(text)
+            | LogicalLineSource::Markup(text)
+            | LogicalLineSource::Html(text)
             | LogicalLineSource::ListItem(text)
             | LogicalLineSource::CodeBody(text)
             | LogicalLineSource::Heading { text, .. } => Some(text),
@@ -440,7 +398,7 @@ impl LogicalLine {
         let text = text.into();
         Self {
             wrap_prefix_width: source_quote_width(&text),
-            source: LogicalLineSource::Text(LazyText::markdown(text)),
+            source: LogicalLineSource::Markup(LazyText::markdown(text)),
             is_block_start,
             ..Self::default()
         }
@@ -484,9 +442,9 @@ impl LogicalLine {
     }
 
     /// Creates one row of a raw HTML block.
-    pub fn html(block: Rc<MarkdownHtml>, row_idx: usize, is_block_start: bool) -> Self {
+    pub fn html(text: impl Into<String>, is_block_start: bool) -> Self {
         Self {
-            source: LogicalLineSource::Html { block, row_idx },
+            source: LogicalLineSource::Html(LazyText::new(text, "html")),
             is_block_start,
             ..Self::default()
         }
@@ -537,26 +495,10 @@ impl LogicalLine {
         self.source.lazy_text()
     }
 
-    pub fn html_block(&self) -> Option<&Rc<MarkdownHtml>> {
-        match &self.source {
-            LogicalLineSource::Html { block, .. } => Some(block),
-            _ => None,
-        }
-    }
-
-    pub fn reuse_html_block(&mut self, cached: &Rc<MarkdownHtml>) {
-        if let LogicalLineSource::Html { block, .. } = &mut self.source {
-            if block.source() == cached.source() {
-                *block = Rc::clone(cached);
-            }
-        }
-    }
-
     /// Clears cached content so the next render uses the current theme.
     pub fn clear_cache(&self) {
         match &self.source {
             LogicalLineSource::TableRow { table, .. } => table.clear_cache(),
-            LogicalLineSource::Html { block, .. } => block.clear_cache(),
             LogicalLineSource::Frontmatter { block, .. } => block.clear_cache(),
             _ => {
                 if let Some(text) = self.lazy_text() {
@@ -655,6 +597,8 @@ impl LogicalLine {
     pub fn text_content(&self) -> String {
         match &self.source {
             LogicalLineSource::Text(text)
+            | LogicalLineSource::Markup(text)
+            | LogicalLineSource::Html(text)
             | LogicalLineSource::ListItem(text)
             | LogicalLineSource::CodeBody(text)
             | LogicalLineSource::Heading { text, .. } => text.text.clone(),
@@ -663,7 +607,6 @@ impl LogicalLine {
                 format!("{left} {}", right.trim_end())
             }
             LogicalLineSource::Output(text) => text.to_string(),
-            LogicalLineSource::Html { block, row_idx } => block.raw_line(*row_idx).to_owned(),
             LogicalLineSource::Frontmatter { block, row_idx } => {
                 block.raw_line(*row_idx).to_owned()
             }
@@ -787,9 +730,6 @@ impl LogicalLine {
     /// Renders text-identical content without syntax highlighting.
     fn render_plain_content(&self, ctx: &LineRenderContext<'_>) -> Line<'static> {
         match &self.source {
-            LogicalLineSource::Html { block, row_idx } => {
-                expand_tabs_in_line(Line::raw(block.raw_line(*row_idx).to_owned()))
-            }
             LogicalLineSource::Frontmatter { block, row_idx } => {
                 expand_tabs_in_line(Line::raw(block.raw_line(*row_idx).to_owned()))
             }
@@ -805,6 +745,8 @@ impl LogicalLine {
     fn render_content(&self, ctx: &LineRenderContext<'_>) -> Line<'static> {
         match &self.source {
             LogicalLineSource::Text(text)
+            | LogicalLineSource::Markup(text)
+            | LogicalLineSource::Html(text)
             | LogicalLineSource::ListItem(text)
             | LogicalLineSource::CodeBody(text)
             | LogicalLineSource::Heading { text, .. } => {
@@ -844,7 +786,6 @@ impl LogicalLine {
                 *cache = Some(rendered);
                 line
             }
-            LogicalLineSource::Html { block, row_idx } => block.line(*row_idx, ctx.theme),
             LogicalLineSource::Frontmatter { block, row_idx } => block.line(*row_idx, ctx.theme),
             LogicalLineSource::CodeInfo { left, right, style } => {
                 let prefix_width = self.prefix_width();
@@ -895,6 +836,95 @@ impl LogicalLine {
             self.is_running,
         );
     }
+}
+
+/// Returns line text eligible for batched syntax highlighting.
+fn batch_text(line: &LogicalLine) -> Option<&LazyText> {
+    match &line.source {
+        LogicalLineSource::Markup(text) | LogicalLineSource::Html(text) => Some(text),
+        _ => None,
+    }
+}
+
+/// Prepares cached line content for a logical range.
+pub(super) fn prepare_lines(
+    lines: &[LogicalLine],
+    range: Range<usize>,
+    ctx: &LineRenderContext<'_>,
+) -> usize {
+    let same_batch =
+        |left: &LogicalLine, right: &LogicalLine| match (batch_text(left), batch_text(right)) {
+            (Some(left), Some(right)) => left.language == right.language,
+            (None, None) => true,
+            _ => false,
+        };
+
+    let end = range.end.min(lines.len());
+    let mut start = range.start.min(end);
+    while start > 0
+        && start < end
+        && batch_text(&lines[start]).is_some()
+        && !lines[start].is_block_start
+        && same_batch(&lines[start - 1], &lines[start])
+    {
+        start -= 1;
+    }
+
+    let mut populated = 0;
+    for batch in lines[start..end].chunk_by(same_batch) {
+        if batch_text(&batch[0]).is_some() {
+            populated += prepare_syntax_batch(batch, ctx);
+        } else {
+            populated += batch
+                .iter()
+                .filter(|line| line.ensure_rendered(ctx))
+                .count();
+        }
+    }
+    populated
+}
+
+/// Highlights a same-language line batch once and fills its missing caches.
+fn prepare_syntax_batch(batch: &[LogicalLine], ctx: &LineRenderContext<'_>) -> usize {
+    if batch
+        .iter()
+        .all(|line| batch_text(line).is_some_and(|text| text.cached.borrow().is_some()))
+    {
+        return 0;
+    }
+
+    let source_len = batch
+        .iter()
+        .filter_map(batch_text)
+        .map(|text| text.text.len() + 1)
+        .sum();
+    let mut source = String::with_capacity(source_len);
+    for line in batch {
+        source.push_str(&batch_text(line).expect("syntax batch line").text);
+        source.push('\n');
+    }
+
+    let mut populated = 0;
+    let mut rendered = ctx
+        .theme
+        .highlight(
+            &source,
+            &batch_text(&batch[0]).expect("syntax batch line").language,
+        )
+        .lines
+        .into_iter();
+    for line in batch {
+        let text = batch_text(line).expect("syntax batch line");
+        let rendered_line = rendered
+            .next()
+            .unwrap_or_else(|| Line::raw(text.text.clone()));
+        let mut cache = text.cached.borrow_mut();
+        if cache.is_none() {
+            *cache = Some(Text::from(expand_tabs_in_line(rendered_line)));
+            populated += 1;
+        }
+    }
+    populated
 }
 
 /// Prepends gutter "▎". Priority: running > active > status > inactive.
@@ -972,8 +1002,7 @@ fn render_table(
     }
 
     let n = table.headers.len();
-    let min_col_width = 3usize; // enough for "…"
-                                // Table frame overhead: left border + right border + n separators between columns.
+    let min_col_width = 3usize;
     let frame_overhead = 3 * n + 1;
 
     let natural_widths: Vec<usize> = (0..n)
@@ -1703,12 +1732,13 @@ mod tests {
     fn source_label(line: &LogicalLine) -> String {
         match &line.source {
             LogicalLineSource::Text(_) => "Text".to_string(),
+            LogicalLineSource::Markup(_) => "Markup".to_string(),
             LogicalLineSource::ListItem(_) => "ListItem".to_string(),
             LogicalLineSource::Heading { level, .. } => format!("Heading({level})"),
             LogicalLineSource::CodeInfo { .. } => "CodeInfo".to_string(),
             LogicalLineSource::CodeBody(_) => "CodeBody".to_string(),
             LogicalLineSource::Output(_) => "Output".to_string(),
-            LogicalLineSource::Html { .. } => "Html".to_string(),
+            LogicalLineSource::Html(_) => "Html".to_string(),
             LogicalLineSource::Frontmatter { .. } => "Frontmatter".to_string(),
             LogicalLineSource::TableRow { .. } => "Table".to_string(),
             LogicalLineSource::Image { .. } => "Image".to_string(),
@@ -1738,6 +1768,19 @@ mod tests {
             })
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    #[test]
+    fn test_prepare_lines_batches_adjacent_markup_blocks() {
+        let lines = vec![
+            LogicalLine::markup_text("# Heading", true),
+            LogicalLine::markup_text("paragraph", true),
+            LogicalLine::markup_text("> quote", true),
+        ];
+        let theme = test_theme();
+        let populated = prepare_lines(&lines, 0..lines.len(), &test_ctx(&theme, 80));
+
+        assert_eq!(populated, 3);
     }
 
     #[test]

--- a/src/apps/tui/markdown/visual.rs
+++ b/src/apps/tui/markdown/visual.rs
@@ -9,7 +9,7 @@ use crate::apps::config::{GUTTER_GLYPH, PREVIEW_FRAME_OVERHEAD};
 
 use super::{
     owned_table, render_table, split_span_lines, FrontmatterBlock, LogicalLine, LogicalLineSource,
-    MarkdownHtml, MarkdownRenderer, MarkdownTable, ModeRenderer, RenderState, SourcePosition,
+    MarkdownRenderer, MarkdownTable, ModeRenderer, RenderState, SourcePosition,
     MAX_BLOCKQUOTE_MARKER_INDENT,
 };
 
@@ -95,14 +95,8 @@ impl Visual<'_, '_> {
         );
         match &node.kind {
             NodeKind::HtmlBlock => {
-                let html = self.source[node.range.clone()].to_owned();
-                let block = Rc::new(MarkdownHtml::new(html));
-                for row_idx in 0..block.len() {
-                    self.push_line(
-                        lines,
-                        LogicalLine::html(Rc::clone(&block), row_idx, row_idx == 0),
-                        state,
-                    );
+                for (row_idx, line) in self.source[node.range.clone()].lines().enumerate() {
+                    self.push_line(lines, LogicalLine::html(line, row_idx == 0), state);
                 }
             }
             NodeKind::Frontmatter { style, raw } => {
@@ -396,12 +390,13 @@ mod tests {
     fn source_label(line: &LogicalLine) -> String {
         match &line.source {
             LogicalLineSource::Text(_) => "Text".to_string(),
+            LogicalLineSource::Markup(_) => "Markup".to_string(),
             LogicalLineSource::ListItem(_) => "ListItem".to_string(),
             LogicalLineSource::Heading { level, .. } => format!("Heading({level})"),
             LogicalLineSource::CodeInfo { .. } => "CodeInfo".to_string(),
             LogicalLineSource::CodeBody(_) => "CodeBody".to_string(),
             LogicalLineSource::Output(_) => "Output".to_string(),
-            LogicalLineSource::Html { .. } => "Html".to_string(),
+            LogicalLineSource::Html(_) => "Html".to_string(),
             LogicalLineSource::Frontmatter { .. } => "Frontmatter".to_string(),
             LogicalLineSource::TableRow { .. } => "Table".to_string(),
             LogicalLineSource::Image { .. } => "Image".to_string(),
@@ -652,7 +647,7 @@ mod tests {
         let lines = render_nodes("<pre>\n\tindented\n</pre>\n");
         let html: Vec<&LogicalLine> = lines
             .iter()
-            .filter(|l| matches!(l.source, LogicalLineSource::Html { .. }))
+            .filter(|l| matches!(l.source, LogicalLineSource::Html(_)))
             .collect();
         assert_eq!(html.len(), 3);
         assert_eq!(html[1].text_content(), "\tindented");
@@ -675,7 +670,7 @@ mod tests {
                 "block",
                 render_nodes("<div class=\"card\">\n</div>\n")
                     .iter()
-                    .find(|l| matches!(l.source, LogicalLineSource::Html { .. }))
+                    .find(|l| matches!(l.source, LogicalLineSource::Html(_)))
                     .unwrap()
                     .render(&ctx),
             ),

--- a/src/apps/tui/preview/mod.rs
+++ b/src/apps/tui/preview/mod.rs
@@ -6,18 +6,17 @@
 //! width-dependent slice described by the layout line:
 //!
 //! ```text
-//! Node → LogicalLine ──┬─ render → rendered Line ─┬─→ terminal row
-//!                      ├─ width  → LayoutLine(s) ─┤
-//!                      └──── render metadata ─────┘
+//! Node → LogicalLine ──┬─ prepare/cache → render → Line ─┬─→ terminal row
+//!                      ├───── width → LayoutLine(s) ─────┤
+//!                      └──────── render metadata ────────┘
 //! ```
 //!
 //! Content or output changes rebuild logical and layout lines. Width changes
 //! rebuild only layout lines. Rendering and interaction use the full layout
 //! index. Final row rendering covers the viewport and its overdraw margin.
-//! Expensive content caches are prefetched one viewport ahead.
+//! Expensive syntax caches are batch-prefetched around the viewport and reused
+//! across unchanged logical rebuilds.
 
-#[cfg(test)]
-use ratatui::text::Line;
 use ratatui::{
     layout::Rect,
     text::Text,
@@ -25,8 +24,7 @@ use ratatui::{
     Frame,
 };
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
+use std::collections::HashMap;
 
 use crate::apps::config::{
     BORDER_HEIGHT, CODE_GUTTER_WIDTH, GUTTER_GLYPH, INLINE_MAX_LINES_DEFAULT,
@@ -40,8 +38,8 @@ use upmd_parser::nodes::Node;
 use upmd_parser::{Codes, Document};
 
 use super::markdown::{
-    highlight_line, LineRenderContext, LogicalLine, MarkdownHtml, MarkdownRenderer, RenderMode,
-    SourcePosition,
+    highlight_line, prepare_lines, LineRenderContext, LogicalLine, LogicalLineSource,
+    MarkdownRenderer, RenderMode, SourcePosition,
 };
 use super::selection::SelectionState;
 use super::wrap::CopyLine;
@@ -109,6 +107,8 @@ pub struct Preview {
     copy_result: Cell<Option<bool>>,
     /// Prefix overhead in chars per code block (non-zero only for blockquote-nested blocks).
     code_prefix_overhead: HashMap<CodeId, usize>,
+    /// Highlighted Markup rows retained while Visual mode is active.
+    markup_line_cache: HashMap<usize, Text<'static>>,
     /// Cache of images referenced by the document, keyed by resolved path.
     images: RefCell<ImageCache>,
     /// Directory that relative image paths resolve against (the open document's dir).
@@ -182,6 +182,7 @@ impl Preview {
             copy_result: Cell::new(None),
             code_index: codes,
             code_prefix_overhead: HashMap::new(),
+            markup_line_cache: HashMap::new(),
             images: RefCell::new(ImageCache::new()),
             image_base_dir,
             mode: Cell::new(RenderMode::Visual),
@@ -261,37 +262,25 @@ impl Preview {
         self.logical_lines = rendered.lines;
         self.code_prefix_overhead = rendered.code_prefix_overhead;
 
-        // Reuse caches from the previous render for unchanged lines. HTML
-        // blocks are reused by whole-block source; other lines match on text.
-        let old_html: HashMap<String, Rc<MarkdownHtml>> = old_lines
-            .iter()
-            .filter_map(LogicalLine::html_block)
-            .map(|block| (block.source().to_owned(), Rc::clone(block)))
-            .collect();
-        let mut old_raw_iter = old_lines
-            .iter_mut()
-            .filter_map(LogicalLine::lazy_text_mut)
-            .peekable();
+        // Reuse lazy render caches from unchanged lines.
+        self.retain_markup_caches(&mut old_lines);
+        let mut old_raw_iter = old_lines.iter_mut().filter_map(LogicalLine::lazy_text_mut);
 
         for line in &mut self.logical_lines {
-            if let Some(block) = line.html_block() {
-                if let Some(cached) = old_html.get(block.source()) {
-                    line.reuse_html_block(cached);
+            if let LogicalLineSource::Markup(text) = &mut line.source {
+                if let Some(cached) = self
+                    .markup_line_cache
+                    .remove(&line.source_position.offset())
+                {
+                    *text.cached.get_mut() = Some(cached);
                 }
                 continue;
             }
             let Some(text) = line.lazy_text_mut() else {
                 continue;
             };
-            while let Some(old) = old_raw_iter.peek() {
-                if text.text == old.text && text.language == old.language && text.spans == old.spans
-                {
-                    if let Some(old) = old_raw_iter.next() {
-                        std::mem::swap(&mut text.cached, &mut old.cached);
-                    }
-                    break;
-                }
-                old_raw_iter.next();
+            if let Some(old) = old_raw_iter.find(|old| text.same_content(old)) {
+                std::mem::swap(&mut text.cached, &mut old.cached);
             }
         }
 
@@ -301,6 +290,18 @@ impl Preview {
 
         if width > 0 {
             self.rebuild_layout_lines_preserving(width, &old_lines);
+        }
+    }
+
+    fn retain_markup_caches(&mut self, lines: &mut [LogicalLine]) {
+        for line in lines {
+            let LogicalLineSource::Markup(text) = &mut line.source else {
+                continue;
+            };
+            if let Some(cached) = text.cached.get_mut().take() {
+                self.markup_line_cache
+                    .insert(line.source_position.offset(), cached);
+            }
         }
     }
 
@@ -637,6 +638,7 @@ impl Preview {
     pub fn set_theme(&mut self, theme: &Theme) {
         self.theme.clone_from(theme);
         self.logical_lines.iter().for_each(|l| l.clear_cache());
+        self.markup_line_cache.clear();
     }
 
     pub fn selected_code_id(&self) -> Option<CodeId> {
@@ -1221,20 +1223,18 @@ impl Preview {
         let end = offset
             .saturating_add(viewport.saturating_mul(2))
             .min(layout_lines.len());
-        let mut prefetched = HashSet::new();
-        let mut populated_caches = 0;
-        for layout_line in &layout_lines[start..end] {
-            if prefetched.insert(layout_line.logical_idx)
-                && layout_line
-                    .logical(&self.logical_lines)
-                    .ensure_rendered(ctx)
-            {
-                populated_caches += 1;
-            }
-        }
+        let Some(first) = layout_lines.get(start) else {
+            return;
+        };
+        let Some(last) = layout_lines.get(end.saturating_sub(1)) else {
+            return;
+        };
+        let logical_range = first.logical_idx..last.logical_idx.saturating_add(1);
+        let prefetched_lines = logical_range.len();
+        let populated_caches = prepare_lines(&self.logical_lines, logical_range, ctx);
         if populated_caches > 0 {
             tracing::debug!(
-                prefetched_lines = prefetched.len(),
+                prefetched_lines,
                 populated_caches,
                 "prefetched preview content caches"
             );
@@ -1280,6 +1280,7 @@ mod tests {
     use super::*;
     use crate::apps::tui::testutil::ansi_line_summary;
     use insta::assert_snapshot;
+    use ratatui::text::Line;
     use std::collections::HashMap;
 
     fn preview_from_markdown(markdown: &str) -> Preview {
@@ -1301,22 +1302,21 @@ mod tests {
     fn html_block_cache_rebuilds() {
         let comment = "<!--\ninside comment\n-->\n";
         let div = "<div>\ninside element\n</div>\n";
-        let block = |p: &Preview| {
-            Rc::clone(
-                p.logical_lines
-                    .iter()
-                    .find_map(LogicalLine::html_block)
-                    .expect("HTML block"),
-            )
-        };
 
         for (name, updated, change_theme, expect_reuse) in [
             ("unchanged", comment, false, true),
-            ("theme changed", comment, true, true),
+            ("theme changed", comment, true, false),
             ("source changed", div, false, false),
         ] {
             let mut preview = preview_from_markdown(comment);
-            let before = block(&preview);
+            let ctx = LineRenderContext {
+                theme: &preview.theme,
+                active_code_id: None,
+                prefer_status_gutter: None,
+                spinner_char: ' ',
+                viewport_width: 80,
+            };
+            prepare_lines(&preview.logical_lines, 0..preview.logical_lines.len(), &ctx);
 
             if change_theme {
                 preview.set_theme(&Theme::new("base16-ocean.dark", true));
@@ -1329,11 +1329,16 @@ mod tests {
             }
             preview.rebuild_view(&HashMap::new());
 
-            assert_eq!(
-                Rc::ptr_eq(&before, &block(&preview)),
-                expect_reuse,
-                "{name}"
-            );
+            let cached: Vec<bool> = preview
+                .logical_lines
+                .iter()
+                .filter_map(|line| match &line.source {
+                    LogicalLineSource::Html(text) => Some(text.cached.borrow().is_some()),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(cached.len(), 3, "{name}");
+            assert_eq!(cached.iter().all(|cached| *cached), expect_reuse, "{name}");
         }
     }
 


### PR DESCRIPTION
## Summary

- batch adjacent `Markup` and HTML rows through shared Syntect preparation
- seed and reuse unchanged `LazyText` caches during rebuilds
- retain `Markup` caches across render-mode switches
- remove the separate HTML block cache

### CPU Profile: switching between mode rapidly

**Before**
<img width="355" alt="image" src="https://github.com/user-attachments/assets/c9a26561-2b23-4898-9b0f-395d7260d963" />

**After**
<img width="355" alt="image" src="https://github.com/user-attachments/assets/7ec1eee8-2a61-4cfd-864a-c7e0bdca456d" />
